### PR TITLE
optional filemanager

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -668,29 +668,29 @@ const options = mkOptions(OPTIONS, {
                 left: {
                     directory1: {
                         label: opt("󰉍 Downloads"),
-                        command: opt("bash -c \"dolphin $HOME/Downloads/\"")
+                        command: opt("bash -c \"$FILEMANAGER $HOME/Downloads/\"")
                     },
                     directory2: {
                         label: opt("󰉏 Videos"),
-                        command: opt("bash -c \"dolphin $HOME/Videos/\"")
+                        command: opt("bash -c \"$FILEMANAGER $HOME/Videos/\"")
                     },
                     directory3: {
                         label: opt("󰚝 Projects"),
-                        command: opt("bash -c \"dolphin $HOME/Projects/\"")
+                        command: opt("bash -c \"$FILEMANAGER $HOME/Projects/\"")
                     },
                 },
                 right: {
                     directory1: {
                         label: opt("󱧶 Documents"),
-                        command: opt("bash -c \"dolphin $HOME/Documents/\"")
+                        command: opt("bash -c \"$FILEMANAGER $HOME/Documents/\"")
                     },
                     directory2: {
                         label: opt("󰉏 Pictures"),
-                        command: opt("bash -c \"dolphin $HOME/Pictures/\"")
+                        command: opt("bash -c \"$FILEMANAGER $HOME/Pictures/\"")
                     },
                     directory3: {
                         label: opt("󱂵 Home"),
-                        command: opt("bash -c \"dolphin $HOME/\"")
+                        command: opt("bash -c \"$FILEMANAGER $HOME/\"")
                     },
                 }
             },


### PR DESCRIPTION
Current configuration of dashboard file paths takes too much time.

There should be easier way to change the file manager.
I recommend the env var solution as the easiest solution, though the users have to set the env var themselves.

There can be a text prompt right before dashboard file paths config, which asks users their file managers. This text prompt then sets the $FILEMANAGER to the given application.

Testing if given application is available can be good to check.