### PR TITLE
Mouse events are released after the OSD is hidden.

### DIFF
--- a/modules/osd/index.ts
+++ b/modules/osd/index.ts
@@ -105,7 +105,8 @@ export default () => Widget.Window({
     layer: "overlay",
     anchor: location.bind("value").as(v => getPosition(v)),
     click_through: true,
-    child: Widget.Box({
+    child: Widget.Overlay({
+        passThrough: true,
         css: "padding: 1px;",
         expand: true,
         child: renderOSD(),

--- a/modules/osd/index.ts
+++ b/modules/osd/index.ts
@@ -104,7 +104,6 @@ export default () => Widget.Window({
             return mon;
         }),
     name: `indicator`,
-    visible: enable.bind("value"),
     class_name: "indicator",
     layer: "overlay",
     anchor: location.bind("value").as(v => getPosition(v)),
@@ -115,6 +114,9 @@ export default () => Widget.Window({
         child: renderOSD(),
     }),
     setup: self => {
+        self.hook(enable, () => {
+            handleReveal(self, "visible");
+        })
         self.hook(brightness, () => {
             handleReveal(self, "visible");
         }, "notify::screen")


### PR DESCRIPTION
NOTE: This is a temporary fix until a better solution is found. The current Gtk component called 'Overlay' can allow click through events, but this component breaks the moment you change ANYTHING about it. In other words, if you: change your overlay to a different monitor, resize it, change margins, change orientation it will then stop allowing passthroughs and we're back to square one.

This fix hides the entire window as a workaround for now. I will have to spend more digging to find a better solution but I also don't want it hijacking the screen so this will do for now.