### PR TITLE
Volume OSD is now strictly bound to volume and is-muted events.

### DIFF
--- a/modules/osd/index.ts
+++ b/modules/osd/index.ts
@@ -67,7 +67,10 @@ const renderOSD = () => {
             }, "notify::kbd")
             self.hook(audio.speaker, () => {
                 handleReveal(self, "reveal_child");
-            })
+            }, "notify::volume")
+            self.hook(audio.speaker, () => {
+                handleReveal(self, "visible");
+            }, "notify::is-muted")
 
         },
         child: Widget.Box({
@@ -125,7 +128,10 @@ export default () => Widget.Window({
         }, "notify::kbd")
         self.hook(audio.speaker, () => {
             handleReveal(self, "visible");
-        })
+        }, "notify::volume")
+        self.hook(audio.speaker, () => {
+            handleReveal(self, "visible");
+        }, "notify::is-muted")
 
     },
 })


### PR DESCRIPTION
There were scenarios where audio stream changes would make their way into the binding that was connected to the speakers which would cause the osd to show when doing things like changing video streams. The binding now listens to specifically volume and muted events only.

Fixes #40 