### PR TITLE
Network module rework

### DIFF
--- a/modules/bar/network/index.ts
+++ b/modules/bar/network/index.ts
@@ -3,60 +3,53 @@ const network = await Service.import("network");
 import options from "options";
 import { openMenu } from "../utils.js";
 
+const { label: networkLabel, truncation, truncation_size } = options.bar.network;
+
 const Network = () => {
-    const wifiIndicator = [
-        Widget.Icon({
-            class_name: "bar-button-icon network",
-            icon: network.wifi.bind("icon_name"),
-        }),
-        Widget.Box({
-            children: Utils.merge(
-                [network.bind("wifi"), options.bar.network.label.bind("value")],
-                (wifi, showLabel) => {
-                    if (!showLabel) {
-                        return [];
-                    }
-                    return [
-                        Widget.Label({
-                            class_name: "bar-button-label network",
-                            label: wifi.ssid ? `${wifi.ssid.substring(0, 7)}` : "--",
-                        }),
-                    ]
-                },
-            )
-        })
-    ];
-
-    const wiredIndicator = [
-        Widget.Icon({
-            class_name: "bar-button-icon network",
-            icon: network.wired.bind("icon_name"),
-        }),
-        Widget.Box({
-            children: Utils.merge(
-                [network.bind("wired"), options.bar.network.label.bind("value")],
-                (_, showLabel) => {
-                    if (!showLabel) {
-                        return [];
-                    }
-                    return [
-                        Widget.Label({
-                            class_name: "bar-button-label network",
-                            label: "Wired",
-                        }),
-                    ]
-                },
-            )
-        })
-    ];
-
     return {
         component: Widget.Box({
             vpack: "center",
             class_name: "bar-network",
-            children: network
-                .bind("primary")
-                .as((w) => (w === "wired" ? wiredIndicator : wifiIndicator)),
+            children: [
+                Widget.Icon({
+                    class_name: "bar-button-icon network",
+                    icon: Utils.merge([
+                        network.bind("primary"),
+                        network.bind("wifi"),
+                        network.bind("wired")
+                    ], (pmry, wfi, wrd) => {
+                        if (pmry === "wired") {
+                            return wrd.icon_name;
+                        }
+                        return wfi.icon_name;
+                    })
+                }),
+                Widget.Box({
+                    class_name: "bar-button-icon network",
+                    child: Utils.merge([
+                        network.bind("primary"),
+                        network.bind("wifi"),
+                        networkLabel.bind("value"),
+                        truncation.bind("value"),
+                        truncation_size.bind("value")
+                    ], (pmry, wfi, showLbl, trunc, tSize) => {
+                        if (!showLbl) {
+                            return Widget.Box();
+                        }
+                        if (pmry === "wired") {
+                            return Widget.Label({
+                                class_name: "bar-button-label network",
+                                label: "Wired".substring(0, tSize),
+                            })
+                        }
+                        return Widget.Label({
+                            class_name: "bar-button-label network",
+                            label: wfi.ssid ? `${trunc ? wfi.ssid.substring(0, tSize) : wfi.ssid}` : "--",
+                        })
+
+                    })
+                }),
+            ]
         }),
         isVisible: true,
         boxClass: "network",

--- a/modules/menus/calendar/weather/index.ts
+++ b/modules/menus/calendar/weather/index.ts
@@ -39,7 +39,7 @@ const WeatherWidget = () => {
                                         return theWeather.value = parsedWeather;
                                     } catch (error) {
                                         theWeather.value = DEFAULT_WEATHER;
-                                        console.error(`Failed to parse weather data: ${error}`);
+                                        console.warn(`Failed to parse weather data: ${error}`);
                                     }
                                 })
                                 .catch((err) => {

--- a/options.ts
+++ b/options.ts
@@ -620,6 +620,8 @@ const options = mkOptions(OPTIONS, {
             label: opt(true),
         },
         network: {
+            truncation: opt(true),
+            truncation_size: opt(7),
             label: opt(true),
         },
         bluetooth: {

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -51,6 +51,8 @@ export const BarSettings = () => {
 
                 Header('Network'),
                 Option({ opt: options.bar.network.label, title: 'Show Network Name', type: 'boolean' }),
+                Option({ opt: options.bar.network.truncation, title: 'Truncate Network Name', subtitle: 'Will truncate the network name to the specified size below.', type: 'boolean' }),
+                Option({ opt: options.bar.network.truncation_size, title: 'Truncation Size', type: 'number' }),
                 Option({ opt: options.theme.bar.buttons.network.spacing, title: 'Inner Spacing', subtitle: 'Spacing between the icon and the label inside the buttons.', type: 'string' }),
 
                 Header('Bluetooth'),


### PR DESCRIPTION
The network module worked by conditionally rendering the wired or wifi component. This would cause the Widgets to get unsafely destroyed (it seems) which would then crash HyprPanel.

Reworked the network module to fix that issue (#45) and to make it significantly more responsive to changes.

Additionally added options in `Configuration > Bar > Network` to:
- Enable truncation of network name (default: enabled)
- Specify truncation size (default: 7)