### PR TITLE
added 'increment' option for Inputter

### DIFF
--- a/lib/types/options.d.ts
+++ b/lib/types/options.d.ts
@@ -22,6 +22,7 @@ export type RowProps<T> = {
     max?: number
     min?: number
     subtitle?: string
+    increment?: number
 }
 
 export type OSDOrientation = "horizontal" | "vertical";

--- a/widget/settings/pages/config/general/index.ts
+++ b/widget/settings/pages/config/general/index.ts
@@ -11,7 +11,7 @@ export const BarGeneral = () => {
             Header('General Settings'),
             Option({ opt: options.theme.font.name, title: 'Font', type: 'font' }),
             Option({ opt: options.theme.font.size, title: 'Font Size', type: 'string' }),
-            Option({ opt: options.theme.font.weight, title: 'Font Weight', subtitle: "100, 200, 300, etc.", type: 'number', increment: 100, min: 100}),
+            Option({ opt: options.theme.font.weight, title: 'Font Weight', subtitle: "100, 200, 300, etc.", type: 'number', increment: 100, min: 100, max: 900}),
             Option({ opt: options.terminal, title: 'Terminal', subtitle: "Tools such as 'btop' will open in this terminal", type: 'string' }),
 
             Header('On Screen Display'),

--- a/widget/settings/pages/config/general/index.ts
+++ b/widget/settings/pages/config/general/index.ts
@@ -11,7 +11,7 @@ export const BarGeneral = () => {
             Header('General Settings'),
             Option({ opt: options.theme.font.name, title: 'Font', type: 'font' }),
             Option({ opt: options.theme.font.size, title: 'Font Size', type: 'string' }),
-            Option({ opt: options.theme.font.weight, title: 'Font Weight', subtitle: "100, 200, 300, etc.", type: 'number' }),
+            Option({ opt: options.theme.font.weight, title: 'Font Weight', subtitle: "100, 200, 300, etc.", type: 'number', increment: 100, min: 100}),
             Option({ opt: options.terminal, title: 'Terminal', subtitle: "Tools such as 'btop' will open in this terminal", type: 'string' }),
 
             Header('On Screen Display'),

--- a/widget/settings/shared/Inputter.ts
+++ b/widget/settings/shared/Inputter.ts
@@ -32,6 +32,7 @@ export const Inputter = <T>({
     enums,
     max = 1000000,
     min = 0,
+    increment = 1
 }: RowProps<T>,
     className: string
 ) => {
@@ -43,7 +44,7 @@ export const Inputter = <T>({
                 case "number": return self.child = Widget.SpinButton({
                     setup(self) {
                         self.set_range(min, max)
-                        self.set_increments(1, 5)
+                        self.set_increments(1 * increment, 5 * increment)
                         self.on("value-changed", () => opt.value = self.value as T)
                         self.hook(opt, () => self.value = opt.value as number)
                     },


### PR DESCRIPTION
fixes #63 

Added an increment option for Inputter. This will allow us to set an scaling increment factor for each spinner button on the config panel.

I also noticed that font-weight will need a minimum value of 100, so I added that as well.

I haven't tested all spinner numbers yet to confirm that font-weight is the only option affected by the issue, so I will leave the issue open until I test them all and commit any more changes related to it. 

Edit: Font weight also has a max value of 900, so I added that as well.