### PR TITLE
Fixed gdkpixbuf import.

### DIFF
--- a/modules/menus/dashboard/profile/index.ts
+++ b/modules/menus/dashboard/profile/index.ts
@@ -1,7 +1,7 @@
 import icons from "../../../icons/index.js";
 import powermenu from "../../power/helpers/actions.js";
 import { PowerOptions } from "lib/types/options.js";
-import GdkPixbuf from "types/@girs/gdkpixbuf-2.0/gdkpixbuf-2.0.js";
+import GdkPixbuf from "gi://GdkPixbuf";
 
 import options from "options";
 const { image, name } = options.menus.dashboard.powermenu.avatar;


### PR DESCRIPTION
Fixed the GdkPixbuf import to resolve to the proper path instead of the types directory. This would cause build failures on certain environments.