### PR TITLE
Workspaces are now handled properly for scrolling when there are no rules defined for them.

### DIFF
--- a/modules/bar/workspaces/index.ts
+++ b/modules/bar/workspaces/index.ts
@@ -67,25 +67,43 @@ const Workspaces = (monitor = -1, ws = 8) => {
     })
 
     const goToNextWS = (): void => {
-        const curWorkspace = hyprland.active.workspace.id;
-        const indexOfWs = currentMonitorWorkspaces.value.indexOf(curWorkspace);
-        let nextIndex = indexOfWs + 1;
-        if (nextIndex >= currentMonitorWorkspaces.value.length) {
-            nextIndex = 0;
-        }
+        if (currentMonitorWorkspaces.value === undefined) {
+            let nextIndex = hyprland.active.workspace.id + 1;
+            if (nextIndex > workspaces.value) {
+                nextIndex = 0;
+            }
+            hyprland.messageAsync(`dispatch workspace ${nextIndex}`)
 
-        hyprland.messageAsync(`dispatch workspace ${currentMonitorWorkspaces.value[nextIndex]}`)
+        } else {
+            const curWorkspace = hyprland.active.workspace.id;
+            const indexOfWs = currentMonitorWorkspaces.value.indexOf(curWorkspace);
+            let nextIndex = indexOfWs + 1;
+            if (nextIndex >= currentMonitorWorkspaces.value.length) {
+                nextIndex = 0;
+            }
+
+            hyprland.messageAsync(`dispatch workspace ${currentMonitorWorkspaces.value[nextIndex]}`)
+        }
     }
 
     const goToPrevWS = (): void => {
-        const curWorkspace = hyprland.active.workspace.id;
-        const indexOfWs = currentMonitorWorkspaces.value.indexOf(curWorkspace);
-        let prevIndex = indexOfWs - 1;
-        if (prevIndex < 0) {
-            prevIndex = currentMonitorWorkspaces.value.length - 1;
-        }
+        if (currentMonitorWorkspaces.value === undefined) {
+            let prevIndex = hyprland.active.workspace.id - 1;
 
-        hyprland.messageAsync(`dispatch workspace ${currentMonitorWorkspaces.value[prevIndex]}`)
+            if (prevIndex <= 0) {
+                prevIndex = workspaces.value;
+            }
+            hyprland.messageAsync(`dispatch workspace ${prevIndex}`)
+        } else {
+            const curWorkspace = hyprland.active.workspace.id;
+            const indexOfWs = currentMonitorWorkspaces.value.indexOf(curWorkspace);
+            let prevIndex = indexOfWs - 1;
+            if (prevIndex < 0) {
+                prevIndex = currentMonitorWorkspaces.value.length - 1;
+            }
+
+            hyprland.messageAsync(`dispatch workspace ${currentMonitorWorkspaces.value[prevIndex]}`)
+        }
     }
 
     function throttle<T extends (...args: any[]) => void>(func: T, limit: number): T {
@@ -150,7 +168,7 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                 child: Widget.Label({
                                     attribute: i,
                                     vpack: "center",
-                                    css: spacing.bind("value").as(sp => `margin: 0rem ${0.375 * sp}rem;`),
+                                    css: spacing.bind("value").as(sp => `margin: 0rem ${0.375 * sp}rem; `),
                                     class_name: Utils.merge(
                                         [
                                             options.bar.workspaces.show_icons.bind("value"),
@@ -163,14 +181,14 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                         ],
                                         (show_icons, show_numbered, numbered_active_indicator) => {
                                             if (show_icons) {
-                                                return `workspace-icon`;
+                                                return `workspace - icon`;
                                             }
                                             if (show_numbered) {
                                                 const numActiveInd = hyprland.active.workspace.id === i
                                                     ? numbered_active_indicator
                                                     : "";
 
-                                                return `workspace-number ${numActiveInd}`;
+                                                return `workspace - number ${numActiveInd} `;
                                             }
                                             return "";
                                         },
@@ -197,7 +215,7 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                                     return available;
                                                 }
                                             }
-                                            return `${i}`;
+                                            return `${i} `;
                                         },
                                     ),
                                     setup: (self) => {

--- a/modules/bar/workspaces/index.ts
+++ b/modules/bar/workspaces/index.ts
@@ -168,7 +168,7 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                 child: Widget.Label({
                                     attribute: i,
                                     vpack: "center",
-                                    css: spacing.bind("value").as(sp => `margin: 0rem ${0.375 * sp}rem; `),
+                                    css: spacing.bind("value").as(sp => `margin: 0rem ${0.375 * sp}rem;`),
                                     class_name: Utils.merge(
                                         [
                                             options.bar.workspaces.show_icons.bind("value"),
@@ -181,14 +181,14 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                         ],
                                         (show_icons, show_numbered, numbered_active_indicator) => {
                                             if (show_icons) {
-                                                return `workspace - icon`;
+                                                return `workspace-icon`;
                                             }
                                             if (show_numbered) {
                                                 const numActiveInd = hyprland.active.workspace.id === i
                                                     ? numbered_active_indicator
                                                     : "";
 
-                                                return `workspace - number ${numActiveInd} `;
+                                                return `workspace-number ${numActiveInd} `;
                                             }
                                             return "";
                                         },
@@ -215,7 +215,7 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                                     return available;
                                                 }
                                             }
-                                            return `${i} `;
+                                            return `${i}`;
                                         },
                                     ),
                                     setup: (self) => {

--- a/modules/bar/workspaces/index.ts
+++ b/modules/bar/workspaces/index.ts
@@ -188,7 +188,7 @@ const Workspaces = (monitor = -1, ws = 8) => {
                                                     ? numbered_active_indicator
                                                     : "";
 
-                                                return `workspace-number ${numActiveInd} `;
+                                                return `workspace-number ${numActiveInd}`;
                                             }
                                             return "";
                                         },


### PR DESCRIPTION
If no rules were defined at all for workspaces then scrolling would break. Scrolling now works appropriately when no rules are defined.

closes #110 