### PR TITLE
Make media label togglable

### DIFF
--- a/modules/bar/media/index.ts
+++ b/modules/bar/media/index.ts
@@ -51,7 +51,7 @@ const Media = () => {
                     : `${truncatedLabel.substring(0, truncatedLabel.length - 3)}...`;
         } else {
             songIcon.value = getIconForPlayer(activePlayer.value?.identity || "");
-            return `${songIcon.value} Media`;
+            return `Media`;
         }
     });
 

--- a/modules/bar/media/index.ts
+++ b/modules/bar/media/index.ts
@@ -4,7 +4,7 @@ import { openMenu } from "../utils.js";
 import options from "options";
 import { getCurrentPlayer } from 'lib/shared/media.js';
 
-const { show_artist, truncation, truncation_size } = options.bar.media;
+const { show_artist, truncation, truncation_size, show_label } = options.bar.media;
 
 const Media = () => {
     const activePlayer = Variable(mpris.players[0]);
@@ -33,8 +33,8 @@ const Media = () => {
 
     const songIcon = Variable("");
 
-    const mediaLabel = Utils.watch("󰎇 Media 󰎇", [mpris, show_artist, truncation, truncation_size], () => {
-        if (activePlayer.value) {
+    const mediaLabel = Utils.watch("󰎇 Media 󰎇", [mpris, show_artist, truncation, truncation_size, show_label], () => {
+        if (activePlayer.value && show_label.value) {
             const { track_title, identity, track_artists } = activePlayer.value;
             songIcon.value = getIconForPlayer(identity);
             const trackArtist = show_artist.value
@@ -50,8 +50,8 @@ const Media = () => {
                     ? `${truncatedLabel}`
                     : `${truncatedLabel.substring(0, truncatedLabel.length - 3)}...`;
         } else {
-            songIcon.value = "";
-            return "󰎇 Media 󰎇";
+            songIcon.value = getIconForPlayer(activePlayer.value?.identity || "");
+            return `${songIcon.value} Media`;
         }
     });
 
@@ -65,6 +65,7 @@ const Media = () => {
                         Widget.Label({
                             class_name: "bar-button-icon media",
                             label: songIcon.bind("value"),
+                            visible: show_label.bind("value"),
                         }),
                         Widget.Label({
                             class_name: "bar-button-label media",

--- a/modules/bar/media/index.ts
+++ b/modules/bar/media/index.ts
@@ -64,8 +64,7 @@ const Media = () => {
                     children: [
                         Widget.Label({
                             class_name: "bar-button-icon media",
-                            label: songIcon.bind("value"),
-                            visible: show_label.bind("value"),
+                            label: songIcon.bind("value").as(v => v || "󰝚"),
                         }),
                         Widget.Label({
                             class_name: "bar-button-label media",

--- a/modules/bar/media/index.ts
+++ b/modules/bar/media/index.ts
@@ -33,7 +33,7 @@ const Media = () => {
 
     const songIcon = Variable("");
 
-    const mediaLabel = Utils.watch("󰎇 Media 󰎇", [mpris, show_artist, truncation, truncation_size, show_label], () => {
+    const mediaLabel = Utils.watch("Media", [mpris, show_artist, truncation, truncation_size, show_label], () => {
         if (activePlayer.value && show_label.value) {
             const { track_title, identity, track_artists } = activePlayer.value;
             songIcon.value = getIconForPlayer(identity);

--- a/options.ts
+++ b/options.ts
@@ -697,7 +697,7 @@ const options = mkOptions(OPTIONS, {
         media: {
             show_artist: opt(false),
             truncation: opt(true),
-            truncation_size: opt(30)
+            truncation_size: opt(0)
         },
         notifications: {
             show_total: opt(false),

--- a/options.ts
+++ b/options.ts
@@ -697,7 +697,7 @@ const options = mkOptions(OPTIONS, {
         media: {
             show_artist: opt(false),
             truncation: opt(true),
-            truncation_size: opt(0)
+            truncation_size: opt(30)
         },
         notifications: {
             show_total: opt(false),

--- a/options.ts
+++ b/options.ts
@@ -697,6 +697,7 @@ const options = mkOptions(OPTIONS, {
         media: {
             show_artist: opt(false),
             truncation: opt(true),
+            show_label: opt(true),
             truncation_size: opt(30)
         },
         notifications: {

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -75,7 +75,7 @@ export const BarSettings = () => {
                 Option({ opt: options.bar.media.show_artist, title: 'Show Track Artist', type: 'boolean' }),
                 Option({ opt: options.bar.media.show_label, title: 'Toggle Media Label', type: 'boolean' }),
                 Option({ opt: options.bar.media.truncation, title: 'Truncate Media Label', subtitle: 'Only applicable if Toggle Media Label is enabled', type: 'boolean' }),
-                Option({ opt: options.bar.media.truncation_size, title: 'Truncation Size', subtitle: 'Only applicable if Toggle Media Label is enabled', type: 'number', min: 0 }),
+                Option({ opt: options.bar.media.truncation_size, title: 'Truncation Size', subtitle: 'Only applicable if Toggle Media Label is enabled', type: 'number', min: 10 }),
 
                 Header('Notifications'),
                 Option({ opt: options.bar.notifications.show_total, title: 'Show Total # of notifications', type: 'boolean' }),

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -74,7 +74,7 @@ export const BarSettings = () => {
                 Option({ opt: options.theme.bar.buttons.media.spacing, title: 'Inner Spacing', subtitle: 'Spacing between the icon and the label inside the buttons.', type: 'string' }),
                 Option({ opt: options.bar.media.show_artist, title: 'Show Track Artist', type: 'boolean' }),
                 Option({ opt: options.bar.media.truncation, title: 'Truncate Media Label', type: 'boolean' }),
-                Option({ opt: options.bar.media.truncation_size, title: 'Truncation Size', type: 'number', min: 10 }),
+                Option({ opt: options.bar.media.truncation_size, title: 'Truncation Size', type: 'number', min: 0 }),
 
                 Header('Notifications'),
                 Option({ opt: options.bar.notifications.show_total, title: 'Show Total # of notifications', type: 'boolean' }),

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -73,8 +73,9 @@ export const BarSettings = () => {
                 Header('Media'),
                 Option({ opt: options.theme.bar.buttons.media.spacing, title: 'Inner Spacing', subtitle: 'Spacing between the icon and the label inside the buttons.', type: 'string' }),
                 Option({ opt: options.bar.media.show_artist, title: 'Show Track Artist', type: 'boolean' }),
-                Option({ opt: options.bar.media.truncation, title: 'Truncate Media Label', type: 'boolean' }),
-                Option({ opt: options.bar.media.truncation_size, title: 'Truncation Size', type: 'number', min: 0 }),
+                Option({ opt: options.bar.media.show_label, title: 'Toggle Media Label', type: 'boolean' }),
+                Option({ opt: options.bar.media.truncation, title: 'Truncate Media Label', subtitle: 'Only applicable if Toggle Media Label is enabled', type: 'boolean' }),
+                Option({ opt: options.bar.media.truncation_size, title: 'Truncation Size', subtitle: 'Only applicable if Toggle Media Label is enabled', type: 'number', min: 0 }),
 
                 Header('Notifications'),
                 Option({ opt: options.bar.notifications.show_total, title: 'Show Total # of notifications', type: 'boolean' }),


### PR DESCRIPTION
Adds the option to completely hide the song title if so desired.
Some people may only want the media icon + the mpris control widget, not the title..
