### PR TITLE
Fixes inconsistent behavior when controlling multiple devices with brightnessctl

### DIFF
--- a/services/Brightness.ts
+++ b/services/Brightness.ts
@@ -18,8 +18,8 @@ class Brightness extends Service {
 
     #kbdMax = get(`--device ${kbd} max`)
     #kbd = get(`--device ${kbd} get`)
-    #screenMax = get("max")
-    #screen = get("get") / (get("max") || 1)
+    #screenMax = get(`--device ${screen} max`)
+    #screen = get(`--device ${screen} get`) / (get(`--device ${screen} max`) || 1)
 
     get kbd() { return this.#kbd }
     get screen() { return this.#screen }
@@ -41,7 +41,7 @@ class Brightness extends Service {
         if (percent > 1)
             percent = 1
 
-        sh(`brightnessctl set ${Math.round(percent * 100)}% -q`).then(() => {
+        sh(`brightnessctl set ${Math.round(percent * 100)}% -d ${screen} -q`).then(() => {
             this.#screen = percent
             this.changed("screen")
         })


### PR DESCRIPTION
Fixes a small issue when multiple devices are controlled by brightnessctl and the current and max values are coming from Device 1 but changes are applied to Device 2.

This should probably be handled by addressing all devices at once and changing them to the desired percentages.
For example by changing all devices with the backlight class: `brightnessctl -c backlight s 20%`.
This sadly seems to be broken in brightnessctl v5.0 though.