### PR TITLE
Added the ability to select workspace underline color and highlight padding.

### DIFF
--- a/options.ts
+++ b/options.ts
@@ -146,7 +146,9 @@ const options = mkOptions(OPTIONS, {
                     occupied: opt(colors.flamingo),
                     active: opt(colors.pink),
                     numbered_active_highlight_border: opt("0.2em"),
-                    numbered_active_text_color: opt(colors.mantle),
+                    numbered_active_highlight_padding: opt("0.2em"),
+                    numbered_active_highlighted_text_color: opt(colors.mantle),
+                    numbered_active_underline_color: opt(colors.pink),
                 },
                 windowtitle: {
                     background: opt(colors.base2),

--- a/scss/style/bar/bar.scss
+++ b/scss/style/bar/bar.scss
@@ -1,9 +1,5 @@
 .bar {
 
-  .transparent {
-    background: transparent;
-  }
-
   .bar-panel-container {
     margin-top: if($bar-floating, $bar-margin_top, 0em);
     margin-bottom: if($bar-floating, $bar-margin_bottom, 0em);

--- a/scss/style/bar/workspace.scss
+++ b/scss/style/bar/workspace.scss
@@ -42,14 +42,14 @@
     }
 
     &.underline {
-      border-bottom: 0.1em solid $bar-buttons-workspaces-numbered_active_text_color;
+      border-bottom: 0.1em solid $bar-buttons-workspaces-numbered_active_underline_color;
     }
 
     &.highlight {
-      color: $bar-buttons-workspaces-numbered_active_text_color;
+      color: $bar-buttons-workspaces-numbered_active_highlighted_text_color;
       border-radius: $bar-buttons-workspaces-numbered_active_highlight_border;
       background-color: $bar-buttons-workspaces-active;
-      padding: 0em 0.2em;
+      padding: 0em $bar-buttons-workspaces-numbered_active_highlight_padding;
     }
   }
 }

--- a/scss/style/settings/dialog.scss
+++ b/scss/style/settings/dialog.scss
@@ -2,10 +2,6 @@ window.settings-dialog {
   background-color: $bar-menus-cards;
   color: $bar-menus-text;
 
-  $padding: 0.5em;
-  $primary_bg: $bar-menus-background;
-  $spacing: 0.4em;
-  $radius: 0.5em;
   $widget-bg: $bar-menus-cards;
   $border: none;
   $fg: $bar-menus-text;

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -35,7 +35,7 @@ export const BarSettings = () => {
                 Option({ opt: options.bar.workspaces.show_numbered, title: 'Show Workspace Numbers', type: 'boolean' }),
                 Option({ opt: options.bar.workspaces.numbered_active_indicator, title: 'Numbered Workspace Identifier', subtitle: 'Only applicable if Workspace Numbers are enabled', type: 'enum', enums: ["underline", "highlight"] }),
                 Option({ opt: options.theme.bar.buttons.workspaces.numbered_active_highlight_border, title: 'Highlight Radius', subtitle: 'Only applicable if Workspace Numbers are enabled', type: 'string' }),
-                Option({ opt: options.theme.bar.buttons.workspaces.numbered_active_text_color, title: 'Highlighted Text Color', subtitle: 'Only applicable if Workspace Numbers are enabled', type: 'color' }),
+                Option({ opt: options.theme.bar.buttons.workspaces.numbered_active_highlight_padding, title: 'Highlight Padding', subtitle: 'Only applicable if Workspace Numbers are enabled', type: 'string' }),
                 Option({ opt: options.bar.workspaces.spacing, title: 'Spacing', subtitle: 'Spacing between workspace icons', type: 'float' }),
                 Option({ opt: options.bar.workspaces.workspaces, title: 'Total Workspaces', type: 'number' }),
                 Option({ opt: options.bar.workspaces.monitorSpecific, title: 'Monitor Specific', subtitle: 'Only workspaces applicable to the monitor will be displayed', type: 'boolean' }),

--- a/widget/settings/pages/theme/bar/index.ts
+++ b/widget/settings/pages/theme/bar/index.ts
@@ -30,6 +30,8 @@ export const BarTheme = () => {
                 Option({ opt: options.theme.bar.buttons.workspaces.available, title: 'Workspace Available Color', type: 'color' }),
                 Option({ opt: options.theme.bar.buttons.workspaces.occupied, title: 'Workspace Occupied Color', type: 'color' }),
                 Option({ opt: options.theme.bar.buttons.workspaces.active, title: 'Workspace Active Color', type: 'color' }),
+                Option({ opt: options.theme.bar.buttons.workspaces.numbered_active_highlighted_text_color, title: 'Highlighted Workspace Text Color', type: 'color' }),
+                Option({ opt: options.theme.bar.buttons.workspaces.numbered_active_underline_color, title: 'Workspace Underline Color', type: 'color' }),
 
                 Header('Window Title'),
                 Option({ opt: options.theme.bar.buttons.windowtitle.background, title: 'Background', type: 'color' }),


### PR DESCRIPTION
There was no option available to change the color of the underline when Numbered Workspaces is selected. Additionally, there was no way to configure the padding/width of the highlighted active workspace.

Both of these are available as options now.

closes #128 