### PR TITLE
Implement a CLI command to change themes.

### DIFF
--- a/globals.ts
+++ b/globals.ts
@@ -1,5 +1,0 @@
-const globalMousePos = Variable([0, 0]);
-
-globalThis["globalMousePos"] = globalMousePos;
-
-export { globalMousePos };

--- a/globals/mousePos.ts
+++ b/globals/mousePos.ts
@@ -1,0 +1,3 @@
+const globalMousePosVar = Variable([0, 0]);
+
+globalThis["globalMousePos"] = globalMousePosVar;

--- a/globals/useTheme.ts
+++ b/globals/useTheme.ts
@@ -2,8 +2,7 @@ import Gio from "gi://Gio"
 import { bash, Notify } from "lib/utils";
 import icons from "lib/icons"
 
-globalThis.useTheme = (themeName: string): void => {
-    const filePath = `.config/ags/themes/${themeName}.json`;
+globalThis.useTheme = (filePath: string): void => {
     const themeOnly = true;
     let file = Gio.File.new_for_path(filePath as string);
     let [success, content] = file.load_contents(null);

--- a/globals/useTheme.ts
+++ b/globals/useTheme.ts
@@ -1,0 +1,85 @@
+import Gio from "gi://Gio"
+import { bash, Notify } from "lib/utils";
+import icons from "lib/icons"
+
+globalThis.useTheme = (themeName: string): void => {
+    const filePath = `.config/ags/themes/${themeName}.json`;
+    const themeOnly = true;
+    let file = Gio.File.new_for_path(filePath as string);
+    let [success, content] = file.load_contents(null);
+
+    if (!success) {
+        console.error(`Failed to import: ${filePath}`);
+        return;
+    }
+
+    Notify({
+        summary: `Importing ${themeOnly ? "Theme" : "Config"}`,
+        body: `Importing: ${filePath}`,
+        iconName: icons.ui.info,
+        timeout: 7000
+    });
+
+    let jsonString = new TextDecoder("utf-8").decode(content);
+    let importedConfig = JSON.parse(jsonString);
+
+    const hexColorPattern = /^#([0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+
+    const saveConfigToFile = (config: object, filePath: string) => {
+        let file = Gio.File.new_for_path(filePath);
+        let outputStream = file.replace(null, false, Gio.FileCreateFlags.NONE, null);
+        let dataOutputStream = new Gio.DataOutputStream({ base_stream: outputStream });
+
+        let jsonString = JSON.stringify(config, null, 2);
+        dataOutputStream.put_string(jsonString, null);
+        dataOutputStream.close(null);
+    };
+
+    const filterConfigForThemeOnly = (config: object) => {
+        let filteredConfig = {};
+        for (let key in config) {
+            if (typeof config[key] === 'string' && hexColorPattern.test(config[key])) {
+                filteredConfig[key] = config[key];
+            }
+        }
+        return filteredConfig;
+    };
+
+    const filterConfigForNonTheme = (config: object) => {
+        let filteredConfig = {};
+        for (let key in config) {
+            if (!(typeof config[key] === 'string' && hexColorPattern.test(config[key]))) {
+                filteredConfig[key] = config[key];
+            }
+        }
+        return filteredConfig;
+    };
+
+    let tmpConfigFile = Gio.File.new_for_path(`${TMP}/config.json`);
+    let optionsConfigFile = Gio.File.new_for_path(OPTIONS);
+
+    let [tmpSuccess, tmpContent] = tmpConfigFile.load_contents(null);
+    let [optionsSuccess, optionsContent] = optionsConfigFile.load_contents(null);
+
+    if (!tmpSuccess || !optionsSuccess) {
+        console.error("Failed to read existing configuration files.");
+        return;
+    }
+
+    let tmpConfig = JSON.parse(new TextDecoder("utf-8").decode(tmpContent));
+    let optionsConfig = JSON.parse(new TextDecoder("utf-8").decode(optionsContent));
+
+    if (themeOnly) {
+        const filteredConfig = filterConfigForThemeOnly(importedConfig);
+        tmpConfig = { ...tmpConfig, ...filteredConfig };
+        optionsConfig = { ...optionsConfig, ...filteredConfig };
+    } else {
+        const filteredConfig = filterConfigForNonTheme(importedConfig);
+        tmpConfig = { ...tmpConfig, ...filteredConfig };
+        optionsConfig = { ...optionsConfig, ...filteredConfig };
+    }
+
+    saveConfigToFile(tmpConfig, `${TMP}/config.json`);
+    saveConfigToFile(optionsConfig, OPTIONS);
+    bash("pkill ags && ags");
+}

--- a/main.ts
+++ b/main.ts
@@ -1,12 +1,14 @@
-import "lib/session"
-import "scss/style"
+import "lib/session";
+import "scss/style";
+import "globals/useTheme";
+import "globals/mousePos";
 
-import { Bar } from "modules/bar/Bar"
+import { Bar } from "modules/bar/Bar";
 import MenuWindows from "./modules/menus/main.js";
-import SettingsDialog from "widget/settings/SettingsDialog"
+import SettingsDialog from "widget/settings/SettingsDialog";
 import Notifications from "./modules/notifications/index.js";
-import { forMonitors } from "lib/utils"
-import OSD from "modules/osd/index"
+import { forMonitors } from "lib/utils";
+import OSD from "modules/osd/index";
 
 App.config({
     onConfigParsed: () => Utils.execAsync(`python3 ${App.configDir}/services/bluetooth.py`),

--- a/modules/bar/utils.ts
+++ b/modules/bar/utils.ts
@@ -1,7 +1,5 @@
 import Gdk from 'gi://Gdk?version=3.0';
 
-import { globalMousePos } from 'globals';
-
 export const closeAllMenus = () => {
     const menuWindows = App.windows
         .filter((w) => {

--- a/modules/menus/DropdownMenu.ts
+++ b/modules/menus/DropdownMenu.ts
@@ -1,5 +1,4 @@
 const hyprland = await Service.import("hyprland");
-import { globalMousePos } from "globals";
 import { Exclusivity } from "lib/types/widget";
 import { bash } from "lib/utils";
 import { Monitor } from "types/service/hyprland";


### PR DESCRIPTION
Added a function that can be called through the CLI/Terminal to change the theme of AGS.
This function takes the path of the theme file as input.

Example usage:
```bash
ags -r "useTheme('$HOME/.config/ags/themes/nord.json')"
```

closes #133