### PR TITLE
The import Config/Theme dialog no longer restarts HyprPanel on cancellation.

### DIFF
--- a/widget/settings/shared/FileChooser.ts
+++ b/widget/settings/shared/FileChooser.ts
@@ -122,6 +122,11 @@ export const importFiles = (themeOnly: boolean = false): void => {
 
     let response = dialog.run();
 
+
+    if (response === Gtk.ResponseType.CANCEL) {
+        dialog.destroy();
+        return;
+    }
     if (response === Gtk.ResponseType.ACCEPT) {
         let filePath = dialog.get_filename();
         let file = Gio.File.new_for_path(filePath as string);


### PR DESCRIPTION
Instead, the dialog simply closes.

closes #141 