### PR TITLE
Fixes a OSD bug when un-/muting and adds a toggle to display volume as 0 when muting

### DIFF
--- a/modules/osd/bar/index.ts
+++ b/modules/osd/bar/index.ts
@@ -26,7 +26,7 @@ export const OSDBar = (ort: OSDOrientation) => {
                         self.value = audio.microphone.volume <= 1 ? audio.microphone.volume : audio.microphone.volume - 1;
                     }, "notify::volume")
                     self.hook(audio.microphone, () => {
-                        self.toggleClassName("overflow", audio.microphone.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.microphone.is_muted !== false)));
+                        self.toggleClassName("overflow", audio.microphone.volume > 1 && (!options.theme.osd.muted_zero.value || audio.microphone.is_muted === false));
                         self.value = (options.theme.osd.muted_zero.value && audio.microphone.is_muted !== false) ? 0 : audio.microphone.volume <= 1 ? audio.microphone.volume : audio.microphone.volume - 1;
                     }, "notify::is-muted")
                     self.hook(audio.speaker, () => {

--- a/modules/osd/bar/index.ts
+++ b/modules/osd/bar/index.ts
@@ -34,7 +34,7 @@ export const OSDBar = (ort: OSDOrientation) => {
                         self.value = audio.speaker.volume <= 1 ? audio.speaker.volume : audio.speaker.volume - 1;
                     }, "notify::volume")
                     self.hook(audio.speaker, () => {
-                        self.toggleClassName("overflow", audio.speaker.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.speaker.is_muted !== false)));
+                        self.toggleClassName("overflow", audio.speaker.volume > 1 && (!options.theme.osd.muted_zero.value || audio.speaker.is_muted === false));
                         self.value = options.theme.osd.muted_zero.value && audio.speaker.is_muted !== false ? 0 : audio.speaker.volume <= 1 ? audio.speaker.volume : audio.speaker.volume - 1;
                     }, "notify::is-muted")
                 }

--- a/modules/osd/bar/index.ts
+++ b/modules/osd/bar/index.ts
@@ -14,9 +14,11 @@ export const OSDBar = (ort: OSDOrientation) => {
                 bar_mode: "continuous",
                 setup: self => {
                     self.hook(brightness, () => {
+                        self.class_names = self.class_names.filter(c => c !== "overflow");
                         self.value = brightness.screen;
                     }, "notify::screen")
                     self.hook(brightness, () => {
+                        self.class_names = self.class_names.filter(c => c !== "overflow");
                         self.value = brightness.kbd;
                     }, "notify::kbd")
                     self.hook(audio.microphone, () => {

--- a/modules/osd/bar/index.ts
+++ b/modules/osd/bar/index.ts
@@ -1,5 +1,6 @@
 import { OSDOrientation } from "lib/types/options";
 import brightness from "services/Brightness"
+import options from "options"
 const audio = await Service.import("audio")
 
 export const OSDBar = (ort: OSDOrientation) => {
@@ -22,10 +23,18 @@ export const OSDBar = (ort: OSDOrientation) => {
                         self.toggleClassName("overflow", audio.microphone.volume > 1)
                         self.value = audio.microphone.volume <= 1 ? audio.microphone.volume : audio.microphone.volume - 1;
                     }, "notify::volume")
+                    self.hook(audio.microphone, () => {
+                        self.toggleClassName("overflow", audio.microphone.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.microphone.is_muted !== false)));
+                        self.value = (options.theme.osd.muted_zero.value && audio.microphone.is_muted !== false) ? 0 : audio.microphone.volume <= 1 ? audio.microphone.volume : audio.microphone.volume - 1;
+                    }, "notify::is-muted")
                     self.hook(audio.speaker, () => {
                         self.toggleClassName("overflow", audio.speaker.volume > 1)
                         self.value = audio.speaker.volume <= 1 ? audio.speaker.volume : audio.speaker.volume - 1;
                     }, "notify::volume")
+                    self.hook(audio.speaker, () => {
+                        self.toggleClassName("overflow", audio.speaker.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.speaker.is_muted !== false)));
+                        self.value = options.theme.osd.muted_zero.value && audio.speaker.is_muted !== false ? 0 : audio.speaker.volume <= 1 ? audio.speaker.volume : audio.speaker.volume - 1;
+                    }, "notify::is-muted")
                 }
             })
         ]

--- a/modules/osd/label/index.ts
+++ b/modules/osd/label/index.ts
@@ -16,9 +16,11 @@ export const OSDLabel = (ort: OSDOrientation) => {
             vpack: "center",
             setup: self => {
                 self.hook(brightness, () => {
+                    self.class_names = self.class_names.filter(c => c !== "overflow");
                     self.label = `${Math.round(brightness.screen * 100)}`;
                 }, "notify::screen")
                 self.hook(brightness, () => {
+                    self.class_names = self.class_names.filter(c => c !== "overflow");
                     self.label = `${Math.round(brightness.kbd * 100)}`;
                 }, "notify::kbd")
                 self.hook(audio.microphone, () => {

--- a/modules/osd/label/index.ts
+++ b/modules/osd/label/index.ts
@@ -28,7 +28,7 @@ export const OSDLabel = (ort: OSDOrientation) => {
                     self.label = `${Math.round(audio.microphone.volume * 100)}`;
                 }, "notify::volume")
                 self.hook(audio.microphone, () => {
-                    self.toggleClassName("overflow", audio.microphone.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.microphone.is_muted !== false)));
+                    self.toggleClassName("overflow", audio.microphone.volume > 1 && (!options.theme.osd.muted_zero.value || audio.microphone.is_muted === false));
                     self.label = `${options.theme.osd.muted_zero.value && audio.microphone.is_muted !== false ? 0 : Math.round(audio.microphone.volume * 100)}`;
                 }, "notify::is-muted")
                 self.hook(audio.speaker, () => {
@@ -36,7 +36,7 @@ export const OSDLabel = (ort: OSDOrientation) => {
                     self.label = `${Math.round(audio.speaker.volume * 100)}`;
                 }, "notify::volume")
                 self.hook(audio.speaker, () => {
-                    self.toggleClassName("overflow", audio.speaker.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.speaker.is_muted !== false)));
+                    self.toggleClassName("overflow", audio.speaker.volume > 1 && (!options.theme.osd.muted_zero.value || audio.speaker.is_muted === false));
                     self.label = `${options.theme.osd.muted_zero.value && audio.speaker.is_muted !== false ? 0 : Math.round(audio.speaker.volume * 100)}`;
                 }, "notify::is-muted")
             }

--- a/modules/osd/label/index.ts
+++ b/modules/osd/label/index.ts
@@ -1,5 +1,6 @@
 import { OSDOrientation } from "lib/types/options";
 import brightness from "services/Brightness"
+import options from "options"
 const audio = await Service.import("audio")
 
 export const OSDLabel = (ort: OSDOrientation) => {
@@ -24,10 +25,18 @@ export const OSDLabel = (ort: OSDOrientation) => {
                     self.toggleClassName("overflow", audio.microphone.volume > 1)
                     self.label = `${Math.round(audio.microphone.volume * 100)}`;
                 }, "notify::volume")
+                self.hook(audio.microphone, () => {
+                    self.toggleClassName("overflow", audio.microphone.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.microphone.is_muted !== false)));
+                    self.label = `${options.theme.osd.muted_zero.value && audio.microphone.is_muted !== false ? 0 : Math.round(audio.microphone.volume * 100)}`;
+                }, "notify::is-muted")
                 self.hook(audio.speaker, () => {
                     self.toggleClassName("overflow", audio.speaker.volume > 1)
                     self.label = `${Math.round(audio.speaker.volume * 100)}`;
                 }, "notify::volume")
+                self.hook(audio.speaker, () => {
+                    self.toggleClassName("overflow", audio.speaker.volume > 1 && (!options.theme.osd.muted_zero.value || !(audio.speaker.is_muted !== false)));
+                    self.label = `${options.theme.osd.muted_zero.value && audio.speaker.is_muted !== false ? 0 : Math.round(audio.speaker.volume * 100)}`;
+                }, "notify::is-muted")
             }
         })
     });

--- a/options.ts
+++ b/options.ts
@@ -117,6 +117,7 @@ const options = mkOptions(OPTIONS, {
             radius: opt("0.4em"),
             margins: opt("0px 5px 0px 0px"),
             location: opt<OSDAnchor>("right"),
+            muted_zero: opt(false),
         },
         bar: {
             floating: opt(false),

--- a/widget/settings/pages/config/osd/index.ts
+++ b/widget/settings/pages/config/osd/index.ts
@@ -16,6 +16,7 @@ export const OSDSettings = () => {
             Option({ opt: options.theme.osd.active_monitor, title: 'Follow Cursor', subtitle: 'The OSD will follow the monitor of your cursor', type: 'boolean' }),
             Option({ opt: options.theme.osd.radius, title: 'Radius', subtitle: 'Radius of the on-screen-display that indicates volume/brightness change', type: 'string' }),
             Option({ opt: options.theme.osd.margins, title: 'Margins', subtitle: 'Margins in the following format: top right bottom left', type: 'string' }),
+            Option({ opt: options.theme.osd.muted_zero, title: 'Mute Volume as Zero', subtitle: 'Display volume as 0 when muting, instead of previous device volume', type: 'boolean' }),
         ]
     })
 }


### PR DESCRIPTION
Since I borked the last PR (#134) I thought I would take the time to explain it more properly now.

This fixes a bug that the displayed values didn't match the actual volume of the affected device, but instead seemed to be stuck on a previously measured value of eg. brightness or something else unrelated.

For example:
- Set microphone volume to 50%
- Increase brightness to 100%
- Mute microphone

The osd icon shows the muted microphone but the label and level bar show 100%, which is unrelated to the microphone.

\
This also implements a toggle to show the volume as "0" when muting the device in the on screen display.

Hope this clarifies it a bit more and thanks for the input @Jas-SinghFSU 