### PR TITLE
implemented xdg-open and '$TERMINAL' environment variable

### DIFF
--- a/modules/menus/dashboard/stats/index.ts
+++ b/modules/menus/dashboard/stats/index.ts
@@ -2,7 +2,6 @@ import options from "options";
 import { GPU_Stat } from "lib/types/gpustat";
 import { dependencies } from "lib/utils";
 
-const { terminal } = options;
 const { enable_gpu } = options.menus.dashboard.stats;
 
 const Stats = () => {
@@ -120,28 +119,24 @@ const Stats = () => {
 
                                 return self.children = [
                                     Widget.Button({
-                                        on_primary_click: terminal.bind("value").as(term => {
-                                            return () => {
-                                                App.closeWindow("dashboardmenu");
-                                                Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                                    (err) => `Failed to open btop: ${err}`,
-                                                );
-                                            }
-                                        }),
+                                        on_primary_click: () => {
+                                            App.closeWindow("dashboardmenu");
+                                            Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                                (err) => `Failed to open btop: ${err}`,
+                                            );
+                                        },
                                         child: Widget.Label({
                                             class_name: "txt-icon",
                                             label: "󰢮",
                                         })
                                     }),
                                     Widget.Button({
-                                        on_primary_click: terminal.bind("value").as(term => {
-                                            return () => {
-                                                App.closeWindow("dashboardmenu");
-                                                Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                                    (err) => `Failed to open btop: ${err}`,
-                                                );
-                                            }
-                                        }),
+                                        on_primary_click: () => {
+                                            App.closeWindow("dashboardmenu");
+                                            Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                                (err) => `Failed to open btop: ${err}`,
+                                            );
+                                        },
                                         child: Widget.LevelBar({
                                             class_name: "stats-bar",
                                             hexpand: true,
@@ -222,28 +217,24 @@ const Stats = () => {
                         vpack: "center",
                         children: [
                             Widget.Button({
-                                on_primary_click: terminal.bind("value").as(term => {
-                                    return () => {
-                                        App.closeWindow("dashboardmenu");
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    }
-                                }),
+                                on_primary_click: () => {
+                                    App.closeWindow("dashboardmenu");
+                                    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                        (err) => `Failed to open btop: ${err}`,
+                                    );
+                                },
                                 child: Widget.Label({
                                     class_name: "txt-icon",
                                     label: "",
                                 })
                             }),
                             Widget.Button({
-                                on_primary_click: terminal.bind("value").as(term => {
-                                    return () => {
-                                        App.closeWindow("dashboardmenu");
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    }
-                                }),
+                                on_primary_click: () => {
+                                    App.closeWindow("dashboardmenu");
+                                    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                        (err) => `Failed to open btop: ${err}`,
+                                    );
+                                },
                                 child: Widget.LevelBar({
                                     class_name: "stats-bar",
                                     hexpand: true,
@@ -271,28 +262,24 @@ const Stats = () => {
                         hexpand: true,
                         children: [
                             Widget.Button({
-                                on_primary_click: terminal.bind("value").as(term => {
-                                    return () => {
-                                        App.closeWindow("dashboardmenu");
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    }
-                                }),
+                               on_primary_click: () => {
+                                    App.closeWindow("dashboardmenu");
+                                    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                        (err) => `Failed to open btop: ${err}`,
+                                    );
+                                },
                                 child: Widget.Label({
                                     class_name: "txt-icon",
                                     label: "",
                                 })
                             }),
                             Widget.Button({
-                                on_primary_click: terminal.bind("value").as(term => {
-                                    return () => {
-                                        App.closeWindow("dashboardmenu");
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    }
-                                }),
+                               on_primary_click: () => {
+                                    App.closeWindow("dashboardmenu");
+                                    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                        (err) => `Failed to open btop: ${err}`,
+                                    );
+                                },
                                 child: Widget.LevelBar({
                                     class_name: "stats-bar",
                                     hexpand: true,
@@ -319,28 +306,24 @@ const Stats = () => {
                         vpack: "center",
                         children: [
                             Widget.Button({
-                                on_primary_click: terminal.bind("value").as(term => {
-                                    return () => {
-                                        App.closeWindow("dashboardmenu");
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    }
-                                }),
+                               on_primary_click: () => {
+                                    App.closeWindow("dashboardmenu");
+                                    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                        (err) => `Failed to open btop: ${err}`,
+                                    );
+                                },
                                 child: Widget.Label({
                                     class_name: "txt-icon",
                                     label: "󰋊",
                                 })
                             }),
                             Widget.Button({
-                                on_primary_click: terminal.bind("value").as(term => {
-                                    return () => {
-                                        App.closeWindow("dashboardmenu");
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    }
-                                }),
+                               on_primary_click: () => {
+                                    App.closeWindow("dashboardmenu");
+                                    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch(
+                                        (err) => `Failed to open btop: ${err}`,
+                                    );
+                                },
                                 child: Widget.LevelBar({
                                     class_name: "stats-bar",
                                     hexpand: true,

--- a/options.ts
+++ b/options.ts
@@ -791,29 +791,29 @@ const options = mkOptions(OPTIONS, {
                 left: {
                     directory1: {
                         label: opt("󰉍 Downloads"),
-                        command: opt("bash -c \"dolphin $HOME/Downloads/\"")
+                        command: opt("bash -c \"xdg-open $HOME/Downloads/\"")
                     },
                     directory2: {
                         label: opt("󰉏 Videos"),
-                        command: opt("bash -c \"dolphin $HOME/Videos/\"")
+                        command: opt("bash -c \"xdg-open $HOME/Videos/\"")
                     },
                     directory3: {
                         label: opt("󰚝 Projects"),
-                        command: opt("bash -c \"dolphin $HOME/Projects/\"")
+                        command: opt("bash -c \"xdg-open $HOME/Projects/\"")
                     },
                 },
                 right: {
                     directory1: {
                         label: opt("󱧶 Documents"),
-                        command: opt("bash -c \"dolphin $HOME/Documents/\"")
+                        command: opt("bash -c \"xdg-open $HOME/Documents/\"")
                     },
                     directory2: {
                         label: opt("󰉏 Pictures"),
-                        command: opt("bash -c \"dolphin $HOME/Pictures/\"")
+                        command: opt("bash -c \"xdg-open $HOME/Pictures/\"")
                     },
                     directory3: {
                         label: opt("󱂵 Home"),
-                        command: opt("bash -c \"dolphin $HOME/\"")
+                        command: opt("bash -c \"xdg-open $HOME/\"")
                     },
                 }
             },
@@ -832,8 +832,6 @@ const options = mkOptions(OPTIONS, {
             }
         }
     },
-
-    terminal: opt("kitty"),
 
     wallpaper: {
         enable: opt(true),

--- a/services/screen_record.sh
+++ b/services/screen_record.sh
@@ -45,7 +45,7 @@ stopRecording() {
         -a "Screen Recorder" \
         -t 10000 \
         -u normal \
-        --action="scriptAction:-dolphin $outputDir=Directory" \
+        --action="scriptAction:-xdg-open $outputDir=Directory" \
         --action="scriptAction:-xdg-open $recentFile=Play"
 }
 

--- a/services/snapshot.sh
+++ b/services/snapshot.sh
@@ -30,6 +30,6 @@ if eval "$command"; then
         -a "Grimblast" \
         -t 7000 \
         -u normal \
-        --action="scriptAction:-dolphin $outputDir=Directory" \
+        --action="scriptAction:-xdg-open $outputDir=Directory" \
         --action="scriptAction:-xdg-open $recentFile=View"
 fi

--- a/widget/settings/pages/config/general/index.ts
+++ b/widget/settings/pages/config/general/index.ts
@@ -24,8 +24,7 @@ export const BarGeneral = () => {
                         themeOnly: false
                     }
                 }),
-                Option({ opt: options.terminal, title: 'Terminal', subtitle: "Tools such as 'btop' will open in this terminal", type: 'string' }),
-
+                
                 Header('Scaling'),
                 Option({ opt: options.theme.bar.scaling, title: 'Bar', type: 'number', min: 1, max: 100, increment: 5 }),
                 Option({ opt: options.theme.notification.scaling, title: 'Notifications', type: 'number', min: 1, max: 100, increment: 5 }),


### PR DESCRIPTION
Removed explicit references to 'dolphin' and replaced them with `xdg-open`

Also removed the hyprpanel option for setting the terminal, and instead replaced references to that with the `$TERMINAL` environment variable.
  - note: as far as I can tell, XDG doesn't have a simple way of opening terminal applications, but the standard workaround for this is to use the `$TERMINAL` envar.


Implementing this PR will require us to add `xdg-desktop-portal` as a dependency (and maybe  `xdg-desktop-portal-hyprland` as well) and either set the `$TERMINAL` envar during the installation script, or include instructions for users to set it.

fixes #21 