### PR TITLE
Fix snapshot script

### DIFF
--- a/services/snapshot.sh
+++ b/services/snapshot.sh
@@ -5,7 +5,7 @@ outputFile="snapshot_$(date +%Y-%m-%d_%H-%M-%S).png"
 outputPath="$outputDir/$outputFile"
 mkdir -p "$outputDir"
 
-mode=$1
+mode=${1:-area}
 
 case "$mode" in
 active)
@@ -18,13 +18,14 @@ area)
     command="grimblast copysave area $outputPath"
     ;;
 *)
+    echo "Invalid option: $mode"
     echo "Usage: $0 {active|output|area}"
     exit 1
     ;;
 esac
 
 if eval "$command"; then
-    recentFile=$(ls -t "$outputDir"/snapshot_*.png | head -n 1)
+    recentFile=$(find "$outputDir" -name 'snapshot_*.png' -printf '%T+ %p\n' | sort -r | head -n 1 | cut -d' ' -f2-)
     notify-send "Grimblast" "Your snapshot has been saved." \
         -i video-x-generic \
         -a "Grimblast" \


### PR DESCRIPTION
The snapshot script added various ways to take screenshots but wouldn't default to any case. Which would cause it to not run. Now the script takes an area snapshot by default; as it was before.