### PR TITLE
24hr time switch set in the Clock Menu now effects notification time also.

### DIFF
--- a/modules/menus/notifications/notification/header/index.ts
+++ b/modules/menus/notifications/notification/header/index.ts
@@ -2,11 +2,15 @@ import GLib from "gi://GLib";
 import { Notification } from "types/service/notifications";
 import { NotificationIcon } from "./icon.js";
 import { notifHasImg } from "../../utils.js";
+import options from "options.js";
 
-const time = (time: number, format = "%I:%M %p") =>
-    GLib.DateTime.new_from_unix_local(time).format(format);
+const { military } = options.menus.clock.time;
 
 export const Header = (notif: Notification) => {
+    const time = (time: number, format = "%I:%M %p") => {
+        return GLib.DateTime.new_from_unix_local(time).format(military.value ? "%H:%M" : format);
+    }
+
     return Widget.Box({
         vertical: false,
         hexpand: true,

--- a/modules/notifications/header/index.ts
+++ b/modules/notifications/header/index.ts
@@ -2,11 +2,15 @@ import GLib from "gi://GLib";
 import { notifHasImg } from "../../menus/notifications/utils.js";
 import { NotificationIcon } from "./icon.js";
 import { Notification } from "types/service/notifications";
+import options from "options.js";
 
-const time = (time: number, format = "%I:%M %p") =>
-    GLib.DateTime.new_from_unix_local(time).format(format);
+const { military } = options.menus.clock.time;
 
 export const Header = (notif: Notification) => {
+    const time = (time: number, format = "%I:%M %p") => {
+        return GLib.DateTime.new_from_unix_local(time).format(military.value ? "%H:%M" : format);
+    }
+
     return Widget.Box({
         vertical: false,
         hexpand: true,


### PR DESCRIPTION
The user can set 24hr time in the clock menu. This setting now takes effect on timestamps provided in the notifications as well.

close #183 