### PR TITLE
Added pagination to the notifications menu and a configurable limit to the amount of notifications spawned.

### DIFF
--- a/modules/bar/Bar.ts
+++ b/modules/bar/Bar.ts
@@ -79,7 +79,7 @@ const getModulesForMonitor = (monitor: number, curLayouts: BarLayout) => {
 const widget = {
     battery: () => WidgetContainer(BatteryLabel()),
     dashboard: () => WidgetContainer(Menu()),
-    workspaces: (monitor: number) => WidgetContainer(Workspaces(monitor, 10)),
+    workspaces: (monitor: number) => WidgetContainer(Workspaces(monitor)),
     windowtitle: () => WidgetContainer(ClientTitle()),
     media: () => WidgetContainer(Media()),
     notifications: () => WidgetContainer(Notifications()),

--- a/modules/menus/notifications/controls/index.ts
+++ b/modules/menus/notifications/controls/index.ts
@@ -1,4 +1,6 @@
-const Controls = (notifs) => {
+import { Notifications } from "types/service/notifications";
+
+const Controls = (notifs: Notifications) => {
     return Widget.Box({
         class_name: "notification-menu-controls",
         expand: false,

--- a/modules/menus/notifications/index.ts
+++ b/modules/menus/notifications/index.ts
@@ -2,25 +2,47 @@ import DropdownMenu from "../DropdownMenu.js";
 const notifs = await Service.import("notifications");
 import { Controls } from "./controls/index.js";
 import { NotificationCard } from "./notification/index.js";
+import { NotificationPager } from "./pager/index.js";
+
+import options from "options";
+
+const { displayedTotal } = options.notifications;
+const { show: showPager } = options.theme.bar.menus.menu.notifications.pager;
 
 export default () => {
-  return DropdownMenu({
-    name: "notificationsmenu",
-    transition: "crossfade",
-    child: Widget.Box({
-      class_name: "notification-menu-content",
-      css: "padding: 1px; margin: -1px;",
-      hexpand: true,
-      vexpand: false,
-      children: [
-        Widget.Box({
-          class_name: "notification-card-container menu",
-          vertical: true,
-          hexpand: false,
-          vexpand: false,
-          children: [Controls(notifs), NotificationCard(notifs)],
+    const curPage = Variable(1);
+
+    Utils.merge([curPage.bind("value"), displayedTotal.bind("value"), notifs.bind("notifications")], (currentPage, dispTotal, notifications) => {
+        // If the page doesn't have enough notifications to display, go back
+        // to the previous page.
+        if (notifications.length <= (currentPage - 1) * dispTotal) {
+            curPage.value = currentPage <= 1 ? 1 : currentPage - 1;
+        }
+    });
+
+    return DropdownMenu({
+        name: "notificationsmenu",
+        transition: "crossfade",
+        child: Widget.Box({
+            class_name: "notification-menu-content",
+            css: "padding: 1px; margin: -1px;",
+            hexpand: true,
+            vexpand: false,
+            children: [
+                Widget.Box({
+                    class_name: "notification-card-container menu",
+                    vertical: true,
+                    hexpand: false,
+                    vexpand: false,
+                    children: showPager.bind("value").as(shPgr => {
+                        if (shPgr) {
+                            return [Controls(notifs), NotificationCard(notifs, curPage), NotificationPager(curPage)];
+                        }
+                        return [Controls(notifs), NotificationCard(notifs, curPage)]
+
+                    })
+                }),
+            ],
         }),
-      ],
-    }),
-  });
+    });
 };

--- a/modules/menus/notifications/notification/index.ts
+++ b/modules/menus/notifications/notification/index.ts
@@ -6,54 +6,63 @@ import { Image } from "./image/index.js";
 import { Placeholder } from "./placeholder/index.js";
 import { Body } from "./body/index.js";
 import { CloseButton } from "./close/index.js";
+import options from "options.js";
+import { Variable } from "types/variable.js";
 
-const NotificationCard = (notifs: Notifications) => {
-    return Widget.Box({
-        class_name: "menu-content-container notifications",
-        hpack: "center",
-        vexpand: true,
-        spacing: 0,
-        vertical: true,
-        setup: (self) => {
-            self.hook(notifs, () => {
-                const sortedNotifications = notifs.notifications.sort(
-                    (a, b) => b.time - a.time,
-                );
+const { displayedTotal } = options.notifications;
 
-                if (notifs.notifications.length <= 0) {
-                    return (self.children = [Placeholder(notifs)]);
-                }
+const NotificationCard = (notifs: Notifications, curPage: Variable<number>) => {
+    return Widget.Scrollable({
+        vscroll: "automatic",
+        child: Widget.Box({
+            class_name: "menu-content-container notifications",
+            hpack: "center",
+            vexpand: true,
+            spacing: 0,
+            vertical: true,
+            setup: (self) => {
+                Utils.merge([notifs.bind("notifications"), curPage.bind("value")], (notifications, currentPage) => {
+                    const sortedNotifications = notifications.sort(
+                        (a, b) => b.time - a.time,
+                    );
 
-                return (self.children = sortedNotifications.map((notif: Notification) => {
-                    return Widget.Box({
-                        class_name: "notification-card-content-container",
-                        children: [
-                            Widget.Box({
-                                class_name: "notification-card menu",
-                                vpack: "start",
-                                hexpand: true,
-                                vexpand: false,
-                                children: [
-                                    Image(notif),
-                                    Widget.Box({
-                                        vpack: "center",
-                                        vertical: true,
-                                        hexpand: true,
-                                        class_name: `notification-card-content ${!notifHasImg(notif) ? "noimg" : " menu"}`,
-                                        children: [
-                                            Header(notif),
-                                            Body(notif),
-                                            Actions(notif, notifs),
-                                        ],
-                                    }),
-                                ],
-                            }),
-                            CloseButton(notif, notifs),
-                        ],
-                    });
-                }));
-            });
-        },
+                    if (notifications.length <= 0) {
+                        return (self.children = [Placeholder(notifs)]);
+                    }
+
+                    const pageStart = (currentPage - 1) * displayedTotal.value;
+                    const pageEnd = currentPage * displayedTotal.value;
+                    return (self.children = sortedNotifications.slice(pageStart, pageEnd).map((notif: Notification) => {
+                        return Widget.Box({
+                            class_name: "notification-card-content-container",
+                            children: [
+                                Widget.Box({
+                                    class_name: "notification-card menu",
+                                    vpack: "start",
+                                    hexpand: true,
+                                    vexpand: false,
+                                    children: [
+                                        Image(notif),
+                                        Widget.Box({
+                                            vpack: "center",
+                                            vertical: true,
+                                            hexpand: true,
+                                            class_name: `notification-card-content ${!notifHasImg(notif) ? "noimg" : " menu"}`,
+                                            children: [
+                                                Header(notif),
+                                                Body(notif),
+                                                Actions(notif, notifs),
+                                            ],
+                                        }),
+                                    ],
+                                }),
+                                CloseButton(notif, notifs),
+                            ],
+                        });
+                    }));
+                });
+            },
+        })
     });
 };
 

--- a/modules/menus/notifications/pager/index.ts
+++ b/modules/menus/notifications/pager/index.ts
@@ -1,0 +1,49 @@
+const notifs = await Service.import("notifications");
+
+import options from "options";
+import { Variable } from "types/variable";
+
+const { displayedTotal } = options.notifications;
+
+export const NotificationPager = (curPage: Variable<number>) => {
+    return Widget.Box({
+        class_name: "notification-menu-pager",
+        hexpand: true,
+        vexpand: false,
+        children: Utils.merge([curPage.bind("value"), displayedTotal.bind("value"), notifs.bind("notifications")], (currentPage, dispTotal, notifications) => {
+            return [
+                Widget.Button({
+                    hexpand: true,
+                    hpack: "start",
+                    class_name: `pager-button left ${currentPage <= 1 ? "disabled" : ""}`,
+                    onPrimaryClick: () => {
+                        curPage.value = currentPage <= 1 ? 1 : currentPage - 1;
+                    },
+                    child: Widget.Label({
+                        className: "pager-button-label",
+                        label: ""
+                    }),
+                }),
+                Widget.Label({
+                    hexpand: true,
+                    hpack: "center",
+                    class_name: "pager-label",
+                    label: `${currentPage} / ${Math.ceil(notifs.notifications.length / dispTotal) || 1}`
+                }),
+                Widget.Button({
+                    hexpand: true,
+                    hpack: "end",
+                    class_name: `pager-button right ${currentPage >= Math.ceil(notifs.notifications.length / dispTotal) ? "disabled" : ""}`,
+                    onPrimaryClick: () => {
+                        const maxPage = Math.ceil(notifs.notifications.length / displayedTotal.value);
+                        curPage.value = currentPage >= maxPage ? currentPage : currentPage + 1;
+                    },
+                    child: Widget.Label({
+                        className: "pager-button-label",
+                        label: ""
+                    }),
+                }),
+            ]
+        })
+    })
+}

--- a/modules/notifications/index.ts
+++ b/modules/notifications/index.ts
@@ -9,7 +9,7 @@ import { CloseButton } from "./close/index.js";
 import { getPosition } from "lib/utils.js";
 const hyprland = await Service.import("hyprland");
 
-const { position, timeout, cache_actions, monitor, active_monitor } = options.notifications;
+const { position, timeout, cache_actions, monitor, active_monitor, displayedTotal } = options.notifications;
 
 
 const curMonitor = Variable(monitor.value);
@@ -47,7 +47,7 @@ export default () => {
             hexpand: true,
             setup: (self) => {
                 self.hook(notifs, () => {
-                    return (self.children = notifs.popups.map((notif) => {
+                    return (self.children = notifs.popups.slice(0, displayedTotal.value).map((notif) => {
                         return Widget.Box({
                             class_name: "notification-card",
                             vpack: "start",

--- a/options.ts
+++ b/options.ts
@@ -629,6 +629,7 @@ const options = mkOptions(OPTIONS, {
                     },
                     notifications: {
                         scaling: opt(100),
+                        height: opt("58em"),
                         label: opt(colors.lavender),
                         no_notifications_label: opt(colors.surface0),
                         background: opt(colors.crust),
@@ -641,6 +642,17 @@ const options = mkOptions(OPTIONS, {
                             disabled: opt(tertiary_colors.surface0),
                             puck: opt(secondary_colors.surface1)
                         },
+                        pager: {
+                            show: opt(true),
+                            background: opt(colors.crust),
+                            button: opt(colors.lavender),
+                            label: opt(colors.overlay1),
+                        },
+                        scrollbar: {
+                            color: opt(colors.lavender),
+                            width: opt("0.35em"),
+                            radius: opt("0.2em")
+                        }
                     },
                 }
             }
@@ -867,6 +879,7 @@ const options = mkOptions(OPTIONS, {
 
     notifications: {
         position: opt<NotificationAnchor>("top right"),
+        displayedTotal: opt(10),
         monitor: opt(0),
         active_monitor: opt(true),
         timeout: opt(7000),

--- a/scss/style/menus/notifications.scss
+++ b/scss/style/menus/notifications.scss
@@ -5,7 +5,7 @@
 .notification-card-container.menu {
   margin: 0em;
   min-width: 30.6em * $bar-menus-menu-notifications-scaling/100;
-  min-height: 48em * $bar-menus-menu-notifications-scaling/100;
+  min-height: $bar-menus-menu-notifications-height * $bar-menus-menu-notifications-scaling/100;
   background: if($bar-menus-monochrome, $bar-menus-background, $bar-menus-menu-notifications-background);
   border: $bar-menus-border-size solid if($bar-menus-monochrome, $bar-menus-border-color, $bar-menus-menu-notifications-border);
   border-radius: $bar-menus-border-radius;
@@ -103,6 +103,19 @@
     color: if($bar-menus-monochrome, $bar-menus-buttons-default, $bar-menus-menu-notifications-clear);
     font-size: 1.5em;
   }
+
+  scrollbar {
+    margin-right: 0.2em;
+    min-width: $bar-menus-menu-notifications-scrollbar-width;
+    border-radius: $bar-menus-menu-notifications-scrollbar-radius;
+    background: transparent;
+
+    slider {
+      min-width: $bar-menus-menu-notifications-scrollbar-width;
+      border-radius: $bar-menus-menu-notifications-scrollbar-radius;
+      background: $bar-menus-menu-notifications-scrollbar-color;
+    }
+  }
 }
 
 .notification-label-container {
@@ -133,5 +146,43 @@
 
   &:hover {
     background: transparentize($notification-close_button-background , 0.5);
+  }
+}
+
+.notification-menu-pager {
+  background: $bar-menus-menu-notifications-pager-background;
+  border-radius: $bar-menus-border-radius;
+  border-top-left-radius: 0em;
+  border-top-right-radius: 0em;
+
+  .pager-button {
+    margin: 0em;
+    padding: 0.25em 1em;
+    color: $bar-menus-menu-notifications-pager-button;
+
+    .pager-button-label {
+      font-size: 2em;
+    }
+
+    &:hover {
+      .pager-button-label {
+        color: transparentize($bar-menus-menu-notifications-pager-button, 0.4);
+        text-decoration: none;
+      }
+    }
+  }
+
+  .pager-label {
+    color: $bar-menus-menu-notifications-pager-label;
+  }
+
+  .disabled {
+    color: transparentize($bar-menus-menu-notifications-pager-button, 0.8);
+
+    &:hover {
+      .pager-button-label {
+        color: transparentize($bar-menus-menu-notifications-pager-button, 0.8);
+      }
+    }
   }
 }

--- a/widget/settings/pages/config/notifications/index.ts
+++ b/widget/settings/pages/config/notifications/index.ts
@@ -17,6 +17,13 @@ export const NotificationSettings = () => {
                 Option({ opt: options.notifications.active_monitor, title: 'Follow Cursor', subtitle: 'The notification will follow the monitor of your cursor', type: 'boolean' }),
                 Option({ opt: options.notifications.timeout, title: 'Notification Timeout', subtitle: 'How long notification popups will last (in milliseconds).', type: 'number' }),
                 Option({ opt: options.notifications.cache_actions, title: 'Preserve Actions', subtitle: 'This will persist the action buttons of a notification after rebooting.', type: 'boolean' }),
+
+                Header('Notification Menu Settings'),
+                Option({ opt: options.theme.bar.menus.menu.notifications.height, title: 'Notification Menu Height', type: 'string' }),
+                Option({ opt: options.notifications.displayedTotal, title: 'Displayed Total', subtitle: 'How many notifications to show in the menu at once.\nNewer notifications will display towards the top.', type: 'number' }),
+                Option({ opt: options.theme.bar.menus.menu.notifications.pager.show, title: 'Show Pager', subtitle: "Shows the pagination footer at the bottom of the menu.", type: 'boolean' }),
+                Option({ opt: options.theme.bar.menus.menu.notifications.scrollbar.width, title: 'Scrollbar Width', type: 'string' }),
+                Option({ opt: options.theme.bar.menus.menu.notifications.scrollbar.radius, title: 'Scrollbar Radius', type: 'string' }),
             ]
         })
     })

--- a/widget/settings/pages/theme/menus/notifications.ts
+++ b/widget/settings/pages/theme/menus/notifications.ts
@@ -26,7 +26,12 @@ export const NotificationsMenuTheme = () => {
                 Option({ opt: options.theme.bar.menus.menu.notifications.switch.disabled, title: 'Disabled', type: 'color' }),
                 Option({ opt: options.theme.bar.menus.menu.notifications.switch.puck, title: 'Puck', type: 'color' }),
 
+                Header('Scrollbar'),
+                Option({ opt: options.theme.bar.menus.menu.notifications.scrollbar.color, title: 'Scrollbar Color', type: 'color' }),
 
+                Header('Pagination'),
+                Option({ opt: options.theme.bar.menus.menu.notifications.pager.button, title: 'Pager Button Color', type: 'color' }),
+                Option({ opt: options.theme.bar.menus.menu.notifications.pager.label, title: 'Pager Label Color', type: 'color' }),
             ]
         })
     })


### PR DESCRIPTION
If too many notifications were created, the panel would consume a large amount of resources to render these notifications even though they wouldn't be visible on the screen. This PR adds a new property that implements pagination so no more than n (default 10) notifications are shown at a time. These notifications now have pagination controls that let you see ALL of your notifications by navigating through the pages; whereas previously you just wouldn't be able to see them.

This solves 2 problems:
1. It lets you have access to all of your notifications visually (instead of majority of your notifications not being visible off-screen)
2. It limits the amount of notifications that have to be rendered at once. This frees up a lot of resources that would otherwise be consumed.