### PR TITLE
Nix hyprland settings exec-once to list of strings instead of single string

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,9 @@ home.packages = with pkgs; [
 ];
 
 # or reference it directly in your Hyprland configuration
-wayland.windowManager.hyprland.settings.exec-once = ''
-  # ...
-  ${pkgs.hyprpanel}/bin/hyprpanel
-  # ...
-'';
+wayland.windowManager.hyprland.settings.exec-once = [
+  "${pkgs.hyprpanel}/bin/hyprpanel"
+];
 
 ```
 


### PR DESCRIPTION
Using a list of strings for the exec-once field is "cleaner" and allows you to reference it in other files without overwriting the initial value of the exec-once field.