### PR TITLE
Made the profile image avatar in the dashboard configurable (size, radius).

### DIFF
--- a/modules/menus/dashboard/profile/index.ts
+++ b/modules/menus/dashboard/profile/index.ts
@@ -35,15 +35,15 @@ const Profile = () => {
                 hexpand: true,
                 vertical: true,
                 children: [
-                    Widget.Icon({
+                    Widget.Box({
                         hpack: "center",
                         class_name: "profile-picture",
-                        icon: image.bind("value").as(i => {
+                        css: image.bind("value").as(i => {
                             try {
                                 GdkPixbuf.Pixbuf.new_from_file(i);
-                                return i;
+                                return `background-image: url("${i}")`
                             } catch {
-                                return "avatar-default-symbolic";
+                                return `background-image: url("${App.configDir}/assets/hyprpanel.png")`
                             }
                         }),
                     }),

--- a/options.ts
+++ b/options.ts
@@ -533,7 +533,9 @@ const options = mkOptions(OPTIONS, {
                             color: opt(colors.surface0),
                         },
                         profile: {
-                            name: opt(colors.pink)
+                            name: opt(colors.pink),
+                            size: opt("8.5em"),
+                            radius: opt("0.4em"),
                         },
                         powermenu: {
                             shutdown: opt(colors.red),

--- a/scss/style/menus/dashboard.scss
+++ b/scss/style/menus/dashboard.scss
@@ -26,7 +26,12 @@
     margin-bottom: 0.65em;
 
     .profile-picture {
-      font-size: 7.5em;
+      min-width: $bar-menus-menu-dashboard-profile-size;
+      min-height: $bar-menus-menu-dashboard-profile-size;
+      border-radius: $bar-menus-menu-dashboard-profile-radius;
+      background-size: cover;
+      background-repeat: no-repeat;
+      background-position: center;
     }
 
     .profile-name {

--- a/widget/settings/pages/config/menus/dashboard.ts
+++ b/widget/settings/pages/config/menus/dashboard.ts
@@ -16,6 +16,8 @@ export const DashboardMenuSettings = () => {
                 Header('Power Menu'),
                 Option({ opt: options.menus.dashboard.powermenu.avatar.image, title: 'Profile Image', type: 'img' }),
                 Option({ opt: options.menus.dashboard.powermenu.avatar.name, title: 'Profile Name', subtitle: 'Use \'system\' to automatically set system name', type: 'string' }),
+                Option({ opt: options.theme.bar.menus.menu.dashboard.profile.size, title: 'Profile Image Size', type: 'string' }),
+                Option({ opt: options.theme.bar.menus.menu.dashboard.profile.radius, title: 'Profile Image Radius', type: 'string' }),
 
                 Option({ opt: options.menus.dashboard.powermenu.confirmation, title: 'Show Confirmation Dialogue', type: 'boolean' }),
                 Option({ opt: options.menus.dashboard.powermenu.shutdown, title: 'Shutdown Command', type: 'string' }),


### PR DESCRIPTION
The radius and size of the profile picture in the Dashboard menu can now be changed in `Configuration > Dashboard Menu > Power Menu`.

closes #208 