### PR TITLE
Indicate that screen recording is active

### DIFF
--- a/modules/menus/dashboard/shortcuts/index.ts
+++ b/modules/menus/dashboard/shortcuts/index.ts
@@ -228,7 +228,8 @@ const Shortcuts = () => {
                     right.shortcut3.command.bind("value"),
                     right.shortcut3.tooltip.bind("value"),
                     right.shortcut3.icon.bind("value"),
-                    leftCardHidden.bind("value")
+                    leftCardHidden.bind("value"),
+                    isRecording.bind("value")
                 ], () => {
                     return Widget.Box({
                         class_name: `container utilities dashboard-card ${!leftCardHidden.value ? "paired" : ""}`,
@@ -264,7 +265,7 @@ const Shortcuts = () => {
                                             command: "record",
                                             icon: "󰑊",
                                             configurable: false
-                                        }, "dashboard-button", "record"),
+                                        }, `dashboard-button record ${isRecording.value ? "active" : ""}`, "record"),
                                     ],
                                 }),
                             }),

--- a/scss/style/menus/dashboard.scss
+++ b/scss/style/menus/dashboard.scss
@@ -137,10 +137,10 @@
         }
 
         &.record.active {
-          background: if($bar-menus-monochrome, $bar-menus-buttons-default, $bar-menus-menu-dashboard-shortcuts-recording);
+          background: $red;
 
           &:hover {
-            background: transparentize(if($bar-menus-monochrome, $bar-menus-buttons-default, $bar-menus-menu-dashboard-shortcuts-recording), 0.5);
+            background: transparentize($red, 0.5);
           }
         }
 


### PR DESCRIPTION
Colors  the screen record button red if there is an ongoing capturing.

Inactive:
![image](https://github.com/user-attachments/assets/1dc9a13a-5edf-4ff9-82c8-eb4ebfe0be42)

Active:
![image](https://github.com/user-attachments/assets/14ab60ae-32cb-43b1-b112-f5ef1905d3c9)