### PR TITLE
Add option for generation of pywal colors with wallpaper change

### DIFF
--- a/modules/bar/Bar.ts
+++ b/modules/bar/Bar.ts
@@ -238,7 +238,7 @@ export const Bar = (() => {
                 class_name: 'bar-panel-container',
                 child: Widget.CenterBox({
                     class_name: 'bar-panel',
-                    css: 'padding: 1px 0px 0px 0px',
+                    css: 'padding: 1px',
                     startWidget: Widget.Box({
                         class_name: "box-left",
                         hexpand: true,

--- a/options.ts
+++ b/options.ts
@@ -876,7 +876,8 @@ const options = mkOptions(OPTIONS, {
 
     wallpaper: {
         enable: opt(true),
-        image: opt("")
+        image: opt(""),
+        pywal: opt(false)
     },
 
     notifications: {

--- a/scss/options_trackers.ts
+++ b/scss/options_trackers.ts
@@ -50,7 +50,7 @@ export const initializeTrackers = (resetCssFunc: Function) => {
             options.resetTheme();
             resetCssFunc();
         }
-        if (options.wallpaper.pywal && dependencies('wal')) {
+        if (options.wallpaper.pywal.value && dependencies('wal')) {
             const wallpaperPath = options.wallpaper.image.value;
             bash(`wal -i ${wallpaperPath}`);
         }

--- a/scss/options_trackers.ts
+++ b/scss/options_trackers.ts
@@ -1,5 +1,5 @@
 import icons from "lib/icons";
-import { Notify, isAnImage } from "lib/utils";
+import { bash, dependencies, Notify, isAnImage } from "lib/utils";
 import options from "options";
 import Wallpaper from "services/Wallpaper";
 
@@ -49,6 +49,10 @@ export const initializeTrackers = (resetCssFunc: Function) => {
             console.info("Wallpaper path changed, regenerating Matugen colors...")
             options.resetTheme();
             resetCssFunc();
+        }
+        if (options.wallpaper.pywal && dependencies('wal')) {
+            const wallpaperPath = options.wallpaper.image.value;
+            bash(`wal -i ${wallpaperPath}`);
         }
     })
 

--- a/widget/settings/pages/theme/menus/index.ts
+++ b/widget/settings/pages/theme/menus/index.ts
@@ -24,6 +24,7 @@ export const MenuTheme = () => {
                     }
                 }),
                 Option({ opt: options.theme.bar.menus.monochrome, title: 'Use Global Colors', type: 'boolean', disabledBinding: options.theme.matugen }),
+                Option({ opt: options.wallpaper.pywal, title: 'Generate Pywal Colors', subtitle: 'Whether to also generate pywal colors with chosen wallpaper', type: 'boolean' }),
                 Option({ opt: options.wallpaper.enable, title: 'Apply Wallpapers', subtitle: 'Whether to apply the wallpaper or to only use it for Matugen color generation.', type: 'boolean' }),
                 Option({ opt: options.wallpaper.image, title: 'Wallpaper', subtitle: options.wallpaper.image.bind("value"), type: 'wallpaper' }),
                 Option({ opt: options.theme.bar.menus.background, title: 'Background Color', type: 'color' }),


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I am still using pywal over matugen for theme generation of a few programs, and I find it useful to automate wal when changing wallpapers from the hyprpanel settings.

**Describe the solution you'd like**
A simple option to enable wal theme generation.

**Describe alternatives you've considered**
Not supporting pywal

**Additional context**
This is something I find useful, maybe others will want it too :-)

![image](https://github.com/user-attachments/assets/edc51eb7-b01a-4154-9a99-e7a7bd847d8d)
