### PR TITLE
Support for apt and ubuntu in CheckUpdates script

### DIFF
--- a/scripts/checkUpdates.sh
+++ b/scripts/checkUpdates.sh
@@ -5,9 +5,17 @@ check_arch_updates() {
     echo "$result"
 }
 
+check_ubuntu_updates() {
+  result=$(apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst)
+  echo "$result"
+}
+
 case "$1" in
 -arch)
     check_arch_updates
+    ;;
+-ubuntu)
+    check_ubuntu_updates
     ;;
 *)
     echo "0"


### PR DESCRIPTION
Small update to support checking updates with the apt package manager. Tested on Ubuntu 24.04 only but it should work on any distro with apt package manager.