### PR TITLE
Add support for dnf and fedora in checkUpdates.sh

### DIFF
--- a/modules/bar/Bar.ts
+++ b/modules/bar/Bar.ts
@@ -279,6 +279,7 @@ export const Bar = (() => {
                 class_name: 'bar-panel-container',
                 child: Widget.CenterBox({
                     class_name: 'bar-panel',
+                    //css: 'padding: 1px 0px 0px 0px',
                     css: 'padding: 1px',
                     startWidget: Widget.Box({
                         class_name: "box-left",

--- a/modules/bar/Bar.ts
+++ b/modules/bar/Bar.ts
@@ -279,7 +279,6 @@ export const Bar = (() => {
                 class_name: 'bar-panel-container',
                 child: Widget.CenterBox({
                     class_name: 'bar-panel',
-                    //css: 'padding: 1px 0px 0px 0px',
                     css: 'padding: 1px',
                     startWidget: Widget.Box({
                         class_name: "box-left",

--- a/scripts/checkUpdates.sh
+++ b/scripts/checkUpdates.sh
@@ -10,12 +10,20 @@ check_ubuntu_updates() {
   echo "$result"
 }
 
+check_fedora_updates() {
+  result=$(dnf check-update -q | grep -v '^Loaded plugins' | grep -v '^No match for' | wc -l)
+  echo "$result"
+}
+
 case "$1" in
 -arch)
     check_arch_updates
     ;;
 -ubuntu)
     check_ubuntu_updates
+    ;;
+-fedora)
+    check_fedora_updates
     ;;
 *)
     echo "0"


### PR DESCRIPTION
Adds dnf package manager compatibility to checkUpdates.sh. In future I'm pondering adding support for flatpaks etc, but I think that's something that should first be discussed for implementation in arch/ubuntu/whatever else as well.