### PR TITLE
Enable screen recorder to use CPU encoder

### DIFF
--- a/services/screen_record.sh
+++ b/services/screen_record.sh
@@ -26,8 +26,10 @@ startRecording() {
         echo "Usage: $0 start screen [screen_name]"
         exit 1
     fi
+    
+    GPU_TYPE=$(lspci | grep -E 'VGA|3D' | grep -Ev '00:02.0|Integrated' > /dev/null && echo "" || echo "-encoder cpu")
 
-    gpu-screen-recorder -w "$target" -f 60 -a "$(pactl get-default-sink).monitor" -o "$outputPath" &
+    gpu-screen-recorder -w "$target" -f 60 -a "$(pactl get-default-sink).monitor" -o "$outputPath" $GPU_TYPE &
 
     echo "Recording started. Output will be saved to $outputPath"
 }


### PR DESCRIPTION
Probably a brief patch, as I know in future gpu-screen-recorder will likely be replaced. This makes it work on laptops without dedicated GPU's though, so very helpful on my setup at least.