### PR TITLE
Added configurable scaling priorities in options.

### DIFF
--- a/lib/types/options.d.ts
+++ b/lib/types/options.d.ts
@@ -213,3 +213,5 @@ type MatugenTheme = 'light' | 'dark';
 
 export type ColorMapKey = keyof typeof defaultColorMap;
 export type ColorMapValue = (typeof defaultColorMap)[ColorMapKey];
+
+export type ScalingPriority = 'gdk' | 'hyprland' | 'both';

--- a/modules/menus/shared/dropdown/locationHandler/index.ts
+++ b/modules/menus/shared/dropdown/locationHandler/index.ts
@@ -1,5 +1,6 @@
 const hyprland = await Service.import('hyprland');
 
+import options from 'options';
 import { bash } from 'lib/utils';
 import { Widget as TWidget } from 'types/@girs/gtk-3.0/gtk-3.0.cjs';
 import { Monitor } from 'types/service/hyprland';
@@ -12,6 +13,7 @@ type NestedBox = Box<NestedRevealer, unknown>;
 type NestedEventBox = EventBox<NestedBox, unknown>;
 
 const { location } = options.theme.bar;
+const { scalingPriority } = options;
 
 export const moveBoxToCursor = <T extends NestedEventBox>(self: T, fixed: boolean): void => {
     if (fixed) {
@@ -49,7 +51,14 @@ export const moveBoxToCursor = <T extends NestedEventBox>(self: T, fixed: boolea
         // end of the monitor is the 1430th pixel.
         const gdkScale = Utils.exec('bash -c "echo $GDK_SCALE"');
 
-        if (/^\d+(.\d+)?$/.test(gdkScale)) {
+        if (scalingPriority.value === 'both') {
+            const scale = parseFloat(gdkScale);
+            monWidth = monWidth / scale;
+            monHeight = monHeight / scale;
+
+            monWidth = monWidth / hyprScaling;
+            monHeight = monHeight / hyprScaling;
+        } else if (/^\d+(.\d+)?$/.test(gdkScale) && scalingPriority.value === 'gdk') {
             const scale = parseFloat(gdkScale);
             monWidth = monWidth / scale;
             monHeight = monHeight / scale;

--- a/options.ts
+++ b/options.ts
@@ -16,6 +16,7 @@ import {
     NotificationAnchor,
     OSDAnchor,
     OSDOrientation,
+    ScalingPriority,
     WindowLayer,
 } from 'lib/types/options';
 import { MatugenScheme, MatugenTheme, MatugenVariations } from 'lib/types/options';
@@ -1052,6 +1053,8 @@ const options = mkOptions(OPTIONS, {
             },
         },
     },
+
+    scalingPriority: opt<ScalingPriority>('gdk'),
 
     terminal: opt('kitty'),
 

--- a/widget/settings/pages/config/general/index.ts
+++ b/widget/settings/pages/config/general/index.ts
@@ -51,6 +51,12 @@ export const BarGeneral = (): Scrollable<Child, Attribute> => {
 
                 Header('Scaling'),
                 Option({
+                    opt: options.scalingPriority,
+                    title: 'Scaling Priority',
+                    type: 'enum',
+                    enums: ['both', 'gdk', 'hyprland'],
+                }),
+                Option({
                     opt: options.theme.bar.scaling,
                     title: 'Bar',
                     type: 'number',


### PR DESCRIPTION
There are 3 ways you can account for scaling in Hyprland.
1. Hyprland scaling
2. GDK scaling
3. Both

There are certain scenario where you only want Hyprland scaling to be accounted for. Other times you want only GDK scaling accounted for and finally in some cases you need both. In scenarios where you have a normal DPI monitor and you set GDK scaling, you would select GDK as the scaling priority. If you have a HiDPI display, you (most likely) want Hyprland scaling as priority. If you are high DPI AND have custom GDK scaling you MAY want both.

Since we can't just assume in hyprpanel, we now have an option to users configure the scaling priority in `Configuration General > Scaling > Scaling Priority`.

The scaling determines where the dropdown menus spawn so it's important to have the right option selected so menus spawn next to where the button is clicked and the screen edges are accounted for propery.

closes #274 