### PR TITLE
fix: unoccupied workspace index

### DIFF
--- a/modules/bar/workspaces/helpers.ts
+++ b/modules/bar/workspaces/helpers.ts
@@ -34,14 +34,15 @@ export const getWorkspaceRules = (): WorkspaceMap => {
 
         const workspaceRules: WorkspaceMap = {};
 
-        JSON.parse(rules).forEach((rule: WorkspaceRule, index: number) => {
+        JSON.parse(rules).forEach((rule: WorkspaceRule) => {
+            const workspaceNum = parseInt(rule.workspaceString, 10);
+            if (isNaN(workspaceNum)) {
+                return;
+            }
             if (Object.hasOwnProperty.call(workspaceRules, rule.monitor)) {
-                const workspaceNum = parseInt(rule.workspaceString, 10);
-                if (!isNaN(workspaceNum)) {
-                    workspaceRules[rule.monitor].push(workspaceNum);
-                }
+                workspaceRules[rule.monitor].push(workspaceNum);
             } else {
-                workspaceRules[rule.monitor] = [index + 1];
+                workspaceRules[rule.monitor] = [workspaceNum];
             }
         });
 


### PR DESCRIPTION
Fixes that workspaces may split as 2-6 and 6-10, now they correctly split as 1-5, 6-10.