### PR TITLE
Added Smart Highlighting for mapped workspaces.

### DIFF
--- a/modules/bar/workspaces/utils.ts
+++ b/modules/bar/workspaces/utils.ts
@@ -5,7 +5,7 @@ import options from 'options';
 const hyprland = await Service.import('hyprland');
 
 const { monochrome, background } = options.theme.bar.buttons;
-const { background: wsBackground, active, hover } = options.theme.bar.buttons.workspaces;
+const { background: wsBackground, active } = options.theme.bar.buttons.workspaces;
 
 const { showWsIcons } = options.bar.workspaces;
 
@@ -48,6 +48,7 @@ export const getWsColor = (wsIconMap: WorkspaceIconMap, i: number, smartHighligh
     if (hasColor && isValidGjsColor(iconEntry.color)) {
         return `color: ${iconEntry.color}; border-bottom-color: ${iconEntry.color};`;
     }
+
     return '';
 };
 

--- a/modules/bar/workspaces/utils.ts
+++ b/modules/bar/workspaces/utils.ts
@@ -29,23 +29,6 @@ const getWsIcon = (wsIconMap: WorkspaceIconMap, i: number): string => {
     return `${i}`;
 };
 
-export const getSmartBackgroundColor = (wsIconMap: WorkspaceIconMap, i: number, smartHighlight: boolean): string => {
-    const iconEntry = wsIconMap[i];
-    if (!iconEntry) {
-        return hover.value;
-    }
-
-    if (typeof iconEntry === 'object' && 'color' in iconEntry && iconEntry.color !== '' && smartHighlight) {
-        return iconEntry.color;
-    }
-
-    return hover.value;
-};
-
-export const getSmartIconColor = (): string => {
-    return wsBackground.value;
-};
-
 export const getWsColor = (wsIconMap: WorkspaceIconMap, i: number, smartHighlight: boolean): string => {
     const iconEntry = wsIconMap[i];
     const hasColor = typeof iconEntry === 'object' && 'color' in iconEntry && isValidGjsColor(iconEntry.color);

--- a/modules/bar/workspaces/utils.ts
+++ b/modules/bar/workspaces/utils.ts
@@ -7,6 +7,8 @@ const hyprland = await Service.import('hyprland');
 const { monochrome, background } = options.theme.bar.buttons;
 const { background: wsBackground, active, hover } = options.theme.bar.buttons.workspaces;
 
+const { showWsIcons } = options.bar.workspaces;
+
 const getWsIcon = (wsIconMap: WorkspaceIconMap, i: number): string => {
     const iconEntry = wsIconMap[i];
 
@@ -46,12 +48,12 @@ export const getSmartIconColor = (): string => {
 
 export const getWsColor = (wsIconMap: WorkspaceIconMap, i: number, smartHighlight: boolean): string => {
     const iconEntry = wsIconMap[i];
-    const hasColor = typeof iconEntry === 'object' && 'color' in iconEntry && iconEntry.color !== '';
+    const hasColor = typeof iconEntry === 'object' && 'color' in iconEntry && isValidGjsColor(iconEntry.color);
     if (!iconEntry) {
         return '';
     }
 
-    if (smartHighlight && hyprland.active.workspace.id === i) {
+    if (showWsIcons.value && smartHighlight && hyprland.active.workspace.id === i) {
         const iconColor = monochrome.value ? background : wsBackground;
         const iconBackground = hasColor && isValidGjsColor(iconEntry.color) ? iconEntry.color : active.value;
         const colorCss = `color: ${iconColor};`;

--- a/modules/bar/workspaces/variants/default.ts
+++ b/modules/bar/workspaces/variants/default.ts
@@ -3,28 +3,15 @@ import options from 'options';
 import { getWorkspaceRules, getWorkspacesForMonitor, isWorkspaceIgnored } from '../helpers';
 import { range } from 'lib/utils';
 import { BoxWidget } from 'lib/types/widget';
-import { getSmartBackgroundColor, getSmartIconColor, getWsColor, renderClassnames, renderLabel } from '../utils';
+import { getWsColor, renderClassnames, renderLabel } from '../utils';
 import { WorkspaceIconMap } from 'lib/types/workspace';
 
 const { workspaces, monitorSpecific, workspaceMask, spacing, ignored } = options.bar.workspaces;
 export const defaultWses = (monitor: number): BoxWidget => {
     return Widget.Box({
         children: Utils.merge(
-            [
-                workspaces.bind('value'),
-                monitorSpecific.bind('value'),
-                options.bar.workspaces.showWsIcons.bind('value'),
-                options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
-                options.bar.workspaces.workspaceIconMap.bind('value'),
-                ignored.bind('value'),
-            ],
-            (
-                workspaces: number,
-                monitorSpecific: boolean,
-                showWsIcons: boolean,
-                smartHighlight: boolean,
-                wsIconMap: WorkspaceIconMap,
-            ) => {
+            [workspaces.bind('value'), monitorSpecific.bind('value'), ignored.bind('value')],
+            (workspaces: number, monitorSpecific: boolean) => {
                 return range(workspaces || 8)
                     .filter((workspaceNumber) => {
                         if (!monitorSpecific) {
@@ -142,11 +129,6 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                     self.hook(hyprland, () => {
                                         self.toggleClassName('active', hyprland.active.workspace.id === i);
                                         self.toggleClassName('occupied', (hyprland.getWorkspace(i)?.windows || 0) > 0);
-                                        if (smartHighlight && showWsIcons) {
-                                            const smartBackground = `background: ${getSmartBackgroundColor(wsIconMap, i, smartHighlight)};`;
-                                            const smartColor = `color: ${getSmartIconColor()};`;
-                                            self.css = `${self.css} .hover-ws label { ${smartBackground} ${smartColor} }`;
-                                        }
                                     });
                                 },
                             }),

--- a/modules/bar/workspaces/variants/default.ts
+++ b/modules/bar/workspaces/variants/default.ts
@@ -32,12 +32,6 @@ export const defaultWses = (monitor: number): BoxWidget => {
                             on_primary_click: () => {
                                 hyprland.messageAsync(`dispatch workspace ${i}`);
                             },
-                            onHover: (self) => {
-                                self.toggleClassName('hover-ws', true);
-                            },
-                            onHoverLost: (self) => {
-                                self.toggleClassName('hover-ws', false);
-                            },
                             child: Widget.Label({
                                 attribute: i,
                                 vpack: 'center',

--- a/modules/bar/workspaces/variants/default.ts
+++ b/modules/bar/workspaces/variants/default.ts
@@ -41,16 +41,18 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         options.bar.workspaces.showWsIcons.bind('value'),
                                         options.bar.workspaces.workspaceIconMap.bind('value'),
                                         options.theme.matugen.bind('value'),
+                                        options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
                                     ],
                                     (
                                         sp: number,
                                         showWsIcons: boolean,
                                         workspaceIconMap: WorkspaceIconMap,
                                         matugen: boolean,
+                                        smartHighlight: boolean,
                                     ) => {
                                         return (
                                             `margin: 0rem ${0.375 * sp}rem;` +
-                                            `${showWsIcons && !matugen ? getWsColor(workspaceIconMap, i) : ''}`
+                                            `${showWsIcons && !matugen ? getWsColor(workspaceIconMap, i, smartHighlight) : ''}`
                                         );
                                     },
                                 ),
@@ -60,6 +62,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         options.bar.workspaces.show_numbered.bind('value'),
                                         options.bar.workspaces.numbered_active_indicator.bind('value'),
                                         options.bar.workspaces.showWsIcons.bind('value'),
+                                        options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
                                         options.bar.workspaces.icons.available.bind('value'),
                                         options.bar.workspaces.icons.active.bind('value'),
                                         hyprland.active.workspace.bind('id'),
@@ -69,12 +72,14 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         showNumbered: boolean,
                                         numberedActiveIndicator: string,
                                         showWsIcons: boolean,
+                                        smartHighlight: boolean,
                                     ) => {
                                         return renderClassnames(
                                             showIcons,
                                             showNumbered,
                                             numberedActiveIndicator,
                                             showWsIcons,
+                                            smartHighlight,
                                             i,
                                         );
                                     },

--- a/modules/bar/workspaces/variants/occupied.ts
+++ b/modules/bar/workspaces/variants/occupied.ts
@@ -2,7 +2,7 @@ const hyprland = await Service.import('hyprland');
 import options from 'options';
 import { getWorkspaceRules, getWorkspacesForMonitor, isWorkspaceIgnored } from '../helpers';
 import { Workspace } from 'types/service/hyprland';
-import { getSmartBackgroundColor, getSmartIconColor, getWsColor, renderClassnames, renderLabel } from '../utils';
+import { getWsColor, renderClassnames, renderLabel } from '../utils';
 import { range } from 'lib/utils';
 import { BoxWidget } from 'lib/types/widget';
 import { WorkspaceIconMap } from 'lib/types/workspace';
@@ -136,9 +136,6 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                                 setup: (self) => {
                                     self.toggleClassName('active', activeId === i);
                                     self.toggleClassName('occupied', (hyprland.getWorkspace(i)?.windows || 0) > 0);
-                                    if (smartHighlight && showWsIcons) {
-                                        self.css = `${self.css} .hover-ws label { background: ${getSmartBackgroundColor(wsIconMap, i, smartHighlight)}; color: ${getSmartIconColor()}; }`;
-                                    }
                                 },
                             }),
                         });

--- a/modules/bar/workspaces/variants/occupied.ts
+++ b/modules/bar/workspaces/variants/occupied.ts
@@ -136,7 +136,7 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                                 setup: (self) => {
                                     self.toggleClassName('active', activeId === i);
                                     self.toggleClassName('occupied', (hyprland.getWorkspace(i)?.windows || 0) > 0);
-                                    if (smartHighlight) {
+                                    if (smartHighlight && showWsIcons) {
                                         self.css = `${self.css} .hover-ws label { background: ${getSmartBackgroundColor(wsIconMap, i, smartHighlight)}; color: ${getSmartIconColor()}; }`;
                                     }
                                 },

--- a/modules/bar/workspaces/variants/occupied.ts
+++ b/modules/bar/workspaces/variants/occupied.ts
@@ -101,12 +101,6 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                             on_primary_click: () => {
                                 hyprland.messageAsync(`dispatch workspace ${i}`);
                             },
-                            onHover: (self) => {
-                                self.toggleClassName('hover-ws', true);
-                            },
-                            onHoverLost: (self) => {
-                                self.toggleClassName('hover-ws', false);
-                            },
                             child: Widget.Label({
                                 attribute: i,
                                 vpack: 'center',

--- a/modules/bar/workspaces/variants/occupied.ts
+++ b/modules/bar/workspaces/variants/occupied.ts
@@ -2,7 +2,7 @@ const hyprland = await Service.import('hyprland');
 import options from 'options';
 import { getWorkspaceRules, getWorkspacesForMonitor, isWorkspaceIgnored } from '../helpers';
 import { Workspace } from 'types/service/hyprland';
-import { getWsColor, renderClassnames, renderLabel } from '../utils';
+import { getSmartBackgroundColor, getSmartIconColor, getWsColor, renderClassnames, renderLabel } from '../utils';
 import { range } from 'lib/utils';
 import { BoxWidget } from 'lib/types/widget';
 import { WorkspaceIconMap } from 'lib/types/workspace';
@@ -28,6 +28,7 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                 options.bar.workspaces.workspaceIconMap.bind('value'),
                 options.bar.workspaces.showWsIcons.bind('value'),
                 options.theme.matugen.bind('value'),
+                options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
                 ignored.bind('value'),
             ],
             (
@@ -46,6 +47,7 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                 wsIconMap: WorkspaceIconMap,
                 showWsIcons: boolean,
                 matugen: boolean,
+                smartHighlight: boolean,
             ) => {
                 let allWkspcs = range(totalWkspcs || 8);
 
@@ -99,17 +101,24 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                             on_primary_click: () => {
                                 hyprland.messageAsync(`dispatch workspace ${i}`);
                             },
+                            onHover: (self) => {
+                                self.toggleClassName('hover-ws', true);
+                            },
+                            onHoverLost: (self) => {
+                                self.toggleClassName('hover-ws', false);
+                            },
                             child: Widget.Label({
                                 attribute: i,
                                 vpack: 'center',
                                 css:
                                     `margin: 0rem ${0.375 * spacing}rem;` +
-                                    `${showWsIcons && !matugen ? getWsColor(wsIconMap, i) : ''}`,
+                                    `${showWsIcons && !matugen ? getWsColor(wsIconMap, i, smartHighlight) : ''}`,
                                 class_name: renderClassnames(
                                     showIcons,
                                     showNumbered,
                                     numberedActiveIndicator,
                                     showWsIcons,
+                                    smartHighlight,
                                     i,
                                 ),
                                 label: renderLabel(
@@ -127,6 +136,9 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                                 setup: (self) => {
                                     self.toggleClassName('active', activeId === i);
                                     self.toggleClassName('occupied', (hyprland.getWorkspace(i)?.windows || 0) > 0);
+                                    if (smartHighlight) {
+                                        self.css = `${self.css} .hover-ws label { background: ${getSmartBackgroundColor(wsIconMap, i, smartHighlight)}; color: ${getSmartIconColor()}; }`;
+                                    }
                                 },
                             }),
                         });

--- a/options.ts
+++ b/options.ts
@@ -188,6 +188,7 @@ const options = mkOptions(OPTIONS, {
                 workspaces: {
                     background: opt(colors.base2),
                     enableBorder: opt(false),
+                    smartHighlight: opt(true),
                     border: opt(colors.pink),
                     available: opt(colors.sky),
                     occupied: opt(colors.flamingo),

--- a/options.ts
+++ b/options.ts
@@ -875,7 +875,7 @@ const options = mkOptions(OPTIONS, {
             workspaces: opt(10),
             spacing: opt(1),
             monitorSpecific: opt(true),
-            hideUnoccupied: opt(false),
+            hideUnoccupied: opt(true),
             workspaceMask: opt(false),
             reverse_scroll: opt(false),
             scroll_speed: opt(5),

--- a/scss/style/bar/notifications.scss
+++ b/scss/style/bar/notifications.scss
@@ -27,6 +27,7 @@
             $bar-buttons-radius * 0.4,
             $bar-buttons-radius
         );
+        color: if($bar-buttons-monochrome, $bar-buttons-icon, $bar-buttons-notifications-icon);
     }
 
     .bar-button-label.notifications {

--- a/scss/style/bar/workspace.scss
+++ b/scss/style/bar/workspace.scss
@@ -44,9 +44,11 @@
         &.underline {
             border-top: 0.1em solid transparent;
             border-bottom: 0.1em solid $bar-buttons-workspaces-numbered_active_underline_color;
+            transition: 0ms;
         }
 
         &.highlight {
+            transition: 0ms;
             color: $bar-buttons-workspaces-numbered_active_highlighted_text_color;
             border-radius: $bar-buttons-workspaces-numbered_active_highlight_border;
             background-color: $bar-buttons-workspaces-active;

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -231,6 +231,14 @@ export const BarSettings = (): Scrollable<Gtk.Widget, Gtk.Widget> => {
                     enums: ['underline', 'highlight', 'color'],
                 }),
                 Option({
+                    opt: options.theme.bar.buttons.workspaces.smartHighlight,
+                    title: 'Smart Highlight',
+                    subtitle:
+                        'Automatically determines the highlight color of the workspace icon.\n' +
+                        'Only compatible with mapped icons.',
+                    type: 'boolean',
+                }),
+                Option({
                     opt: options.theme.bar.buttons.workspaces.numbered_active_highlight_border,
                     title: 'Highlight Radius',
                     subtitle: 'Only applicable if Workspace Numbers are enabled',


### PR DESCRIPTION
Since mapped workspace icons can have their own color, it's a bit inconvenient to assign a single highlight color (if highlight is selected as a WS identifier) because color contrast might just not be sufficient enough. For example, pink highlight on cyan icons is just gross and unreadable.

Smart highlight inverts the colors. So if the active workspace icon was set to blue, the highlight becomes the color of the icon (blue in this case) and the icon color becomes the workspace background color (usually a dark color). So that way there is sufficient contrast and highlights look good.

Option can be found in `Configuration > Bar > Workspaces > Smart Highlight`.