### PR TITLE
Added the options to allow workspaces to be indicated as active on multiple monitors.

### DIFF
--- a/modules/bar/workspaces/variants/default.ts
+++ b/modules/bar/workspaces/variants/default.ts
@@ -5,6 +5,7 @@ import { range } from 'lib/utils';
 import { BoxWidget } from 'lib/types/widget';
 import { getWsColor, renderClassnames, renderLabel } from '../utils';
 import { WorkspaceIconMap } from 'lib/types/workspace';
+import { Monitor } from 'types/service/hyprland';
 
 const { workspaces, monitorSpecific, workspaceMask, spacing, ignored } = options.bar.workspaces;
 export const defaultWses = (monitor: number): BoxWidget => {
@@ -42,6 +43,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         options.bar.workspaces.workspaceIconMap.bind('value'),
                                         options.theme.matugen.bind('value'),
                                         options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
+                                        hyprland.bind('monitors'),
                                         hyprland.active.workspace.bind('id'),
                                     ],
                                     (
@@ -50,10 +52,11 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         workspaceIconMap: WorkspaceIconMap,
                                         matugen: boolean,
                                         smartHighlight: boolean,
+                                        monitors: Monitor[],
                                     ) => {
                                         return (
                                             `margin: 0rem ${0.375 * sp}rem;` +
-                                            `${showWsIcons && !matugen ? getWsColor(workspaceIconMap, i, smartHighlight) : ''}`
+                                            `${showWsIcons && !matugen ? getWsColor(workspaceIconMap, i, smartHighlight, monitor, monitors) : ''}`
                                         );
                                     },
                                 ),
@@ -64,6 +67,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         options.bar.workspaces.numbered_active_indicator.bind('value'),
                                         options.bar.workspaces.showWsIcons.bind('value'),
                                         options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
+                                        hyprland.bind('monitors'),
                                         options.bar.workspaces.icons.available.bind('value'),
                                         options.bar.workspaces.icons.active.bind('value'),
                                         hyprland.active.workspace.bind('id'),
@@ -74,6 +78,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         numberedActiveIndicator: string,
                                         showWsIcons: boolean,
                                         smartHighlight: boolean,
+                                        monitors: Monitor[],
                                     ) => {
                                         return renderClassnames(
                                             showIcons,
@@ -81,6 +86,8 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                             numberedActiveIndicator,
                                             showWsIcons,
                                             smartHighlight,
+                                            monitor,
+                                            monitors,
                                             i,
                                         );
                                     },
@@ -94,6 +101,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         options.bar.workspaces.workspaceIconMap.bind('value'),
                                         options.bar.workspaces.showWsIcons.bind('value'),
                                         workspaceMask.bind('value'),
+                                        hyprland.bind('monitors'),
                                         hyprland.active.workspace.bind('id'),
                                     ],
                                     (
@@ -104,6 +112,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                         wsIconMap: WorkspaceIconMap,
                                         showWsIcons: boolean,
                                         workspaceMask: boolean,
+                                        monitors: Monitor[],
                                     ) => {
                                         return renderLabel(
                                             showIcons,
@@ -116,6 +125,7 @@ export const defaultWses = (monitor: number): BoxWidget => {
                                             i,
                                             index,
                                             monitor,
+                                            monitors,
                                         );
                                     },
                                 ),

--- a/modules/bar/workspaces/variants/occupied.ts
+++ b/modules/bar/workspaces/variants/occupied.ts
@@ -1,13 +1,13 @@
 const hyprland = await Service.import('hyprland');
 import options from 'options';
 import { getWorkspaceRules, getWorkspacesForMonitor, isWorkspaceIgnored } from '../helpers';
-import { Workspace } from 'types/service/hyprland';
+import { Monitor, Workspace } from 'types/service/hyprland';
 import { getWsColor, renderClassnames, renderLabel } from '../utils';
 import { range } from 'lib/utils';
 import { BoxWidget } from 'lib/types/widget';
 import { WorkspaceIconMap } from 'lib/types/workspace';
 
-const { workspaces, monitorSpecific, workspaceMask, spacing, ignored } = options.bar.workspaces;
+const { workspaces, monitorSpecific, workspaceMask, spacing, ignored, showAllActive } = options.bar.workspaces;
 
 export const occupiedWses = (monitor: number): BoxWidget => {
     return Widget.Box({
@@ -29,7 +29,9 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                 options.bar.workspaces.showWsIcons.bind('value'),
                 options.theme.matugen.bind('value'),
                 options.theme.bar.buttons.workspaces.smartHighlight.bind('value'),
+                hyprland.bind('monitors'),
                 ignored.bind('value'),
+                showAllActive.bind('value'),
             ],
             (
                 monitorSpecific: boolean,
@@ -48,6 +50,7 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                 showWsIcons: boolean,
                 matugen: boolean,
                 smartHighlight: boolean,
+                monitors: Monitor[],
             ) => {
                 let allWkspcs = range(totalWkspcs || 8);
 
@@ -106,13 +109,15 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                                 vpack: 'center',
                                 css:
                                     `margin: 0rem ${0.375 * spacing}rem;` +
-                                    `${showWsIcons && !matugen ? getWsColor(wsIconMap, i, smartHighlight) : ''}`,
+                                    `${showWsIcons && !matugen ? getWsColor(wsIconMap, i, smartHighlight, monitor, monitors) : ''}`,
                                 class_name: renderClassnames(
                                     showIcons,
                                     showNumbered,
                                     numberedActiveIndicator,
                                     showWsIcons,
                                     smartHighlight,
+                                    monitor,
+                                    monitors,
                                     i,
                                 ),
                                 label: renderLabel(
@@ -126,6 +131,7 @@ export const occupiedWses = (monitor: number): BoxWidget => {
                                     i,
                                     index,
                                     monitor,
+                                    monitors,
                                 ),
                                 setup: (self) => {
                                     self.toggleClassName('active', activeId === i);

--- a/options.ts
+++ b/options.ts
@@ -862,6 +862,7 @@ const options = mkOptions(OPTIONS, {
         },
         workspaces: {
             show_icons: opt(false),
+            showAllActive: opt(true),
             ignored: opt(''),
             show_numbered: opt(false),
             showWsIcons: opt(false),

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -191,6 +191,11 @@ export const BarSettings = (): Scrollable<Gtk.Widget, Gtk.Widget> => {
                     type: 'boolean',
                 }),
                 Option({
+                    opt: options.bar.workspaces.showAllActive,
+                    title: 'Mark Active Workspace On All Monitors',
+                    type: 'boolean',
+                }),
+                Option({
                     opt: options.theme.bar.buttons.workspaces.fontSize,
                     title: 'Indicator Size',
                     subtitle:

--- a/widget/settings/pages/config/bar/index.ts
+++ b/widget/settings/pages/config/bar/index.ts
@@ -193,6 +193,7 @@ export const BarSettings = (): Scrollable<Gtk.Widget, Gtk.Widget> => {
                 Option({
                     opt: options.bar.workspaces.showAllActive,
                     title: 'Mark Active Workspace On All Monitors',
+                    subtitle: 'Marks the currently active workspace on each monitor.',
                     type: 'boolean',
                 }),
                 Option({


### PR DESCRIPTION
The active workspace indicator (highlight, underline, color or selected icon) would only show on the active workspace on the currently focused monitor. This PR adds an option (enabled by default) to show the active workspace indicator on all monitors instead of just the active one.

Option can be enabled in `Configuration > Bar > Workspaces > Mark Active Workspace On All Monitors`.

closes #286