### PR TITLE
Added a CLI method to check the visibility of a window.

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -6,6 +6,7 @@ import { Options, Variable as VariableType } from 'types/variable';
 declare global {
     var globalMousePos: VariableType<number[]>;
     var useTheme: (filePath: string) => void;
+    var isWindowVisible: (windowName: string) => boolean;
     var globalWeatherVar: VariableType<Weather>;
     var options: Options;
     var removingNotifications: VariableType<boolean>;

--- a/globals/utilities.ts
+++ b/globals/utilities.ts
@@ -1,0 +1,8 @@
+globalThis.isWindowVisible = (windowName: string): boolean => {
+    const appWindow = App.getWindow(windowName);
+
+    if (appWindow === undefined) {
+        return false;
+    }
+    return appWindow.visible;
+};

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,7 @@
 import 'lib/session';
 import 'scss/style';
 import 'globals/useTheme';
+import 'globals/utilities';
 import 'globals/mousePos';
 
 import { Bar } from 'modules/bar/Bar';


### PR DESCRIPTION
For example, a bar can be checked if it's visible or now via:
```bash
ags -r "isWindowVisible('bar-0')"
```
For bars it:
```
bar-n
```
Where `n` is the index of your monitor (0 is your primary one usually, so `bar-0`).

For menus such as the volume, dashboard or media menu, you can refer to the menu names here https://hyprpanel.com/configuration/cli.html#toggling-menus.

For example, to check if the dashboard menu is active you can type:

```bash
ags -r "isWindowVisible('dashboardmenu')"
```