### PR TITLE
[Nix] remove `gnome` attrset access for `gnome-bluetooth`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
               pkgsFor.${system}.grimblast
               pkgsFor.${system}.gpu-screen-recorder
               pkgsFor.${system}.brightnessctl
-              pkgsFor.${system}.gnome.gnome-bluetooth
+              pkgsFor.${system}.gnome-bluetooth
               pkgsFor.${system}.python3
               pkgsFor.${system}.matugen
               inputs.ags.packages.${system}.agsWithTypes

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,7 +21,7 @@
   swww,
   python3,
   libgtop,
-  gnome.gnome-bluetooth,
+  gnome-bluetooth,
   gobject-introspection,
   glib,
 }: let
@@ -55,7 +55,7 @@ in {
   desktop = {
     inherit config;
     script = writeShellScriptBin pname ''
-      export PATH=$PATH:${lib.makeBinPath [dart-sass fd btop pipewire bluez bluez-tools networkmanager matugen swww grimblast gpu-screen-recorder brightnessctl gnome.gnome-bluetooth python3]}
+      export PATH=$PATH:${lib.makeBinPath [dart-sass fd btop pipewire bluez bluez-tools networkmanager matugen swww grimblast gpu-screen-recorder brightnessctl gnome-bluetooth python3]}
       export GI_TYPELIB_PATH=${libgtop}/lib/girepository-1.0:${glib}/lib/girepository-1.0:$GI_TYPELIB_PATH
       ${ags}/bin/ags -b hyprpanel -c ${config}/config.js $@
     '';


### PR DESCRIPTION
Fixes https://github.com/Jas-SinghFSU/HyprPanel/issues/306
Reverts https://github.com/Jas-SinghFSU/HyprPanel/pull/305

Access to the `gnome-bluetooth` attribute from the `gnome` attribute set is only supported now on stable channels and will be removed from them with the upcoming 24.11 release. This pull request changes the `flake.nix` and `default.nix` files respectively to use the new way of accessing `gnome-bluetooth`.

Users of this package that have `inputs.nixpkgs.follows = "nixpkgs"` like some in https://github.com/Jas-SinghFSU/HyprPanel/issues/291 will have been getting a warning for quite some time now about this deprecation. Their issue may be related to what their `nixpkgs` input actually follows, be it master or another channel.

Reference: https://github.com/NixOS/nixpkgs/pull/333917
https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=gnome-bluetooth
https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=gnome-bluetooth