### PR TITLE
Update Brightness.ts to grab a keyboard backlight device.

### DIFF
--- a/services/Brightness.ts
+++ b/services/Brightness.ts
@@ -5,7 +5,7 @@ if (!dependencies('brightnessctl')) App.quit();
 
 const get = (args: string): number => Number(Utils.exec(`brightnessctl ${args}`));
 const screen = await bash`ls -w1 /sys/class/backlight | head -1`;
-const kbd = await bash`ls -w1 /sys/class/leds | head -1`;
+const kbd = await bash`ls -w1 /sys/class/leds | grep '::kbd_backlight$' | head -1`;
 
 class Brightness extends Service {
     static {


### PR DESCRIPTION
On my machine, `ls -w1 /sys/class/leds` returns:

```bash
❯ ls -w1 /sys/class/leds
input4::capslock
input4::numlock
input4::scrolllock
input6::capslock
input6::compose
input6::kana
input6::numlock
input6::scrolllock
smc::kbd_backlight
```

This means that line 8 in [`Brightness.ts`](services/Brightness.ts) sets the `kbd` constant to `input4::capslock` instead of the correct value of `smc::kbd_backlight`.

This pull request aims to target keyboard backlight devices by grepping for the string "::kbd_backlight" in the directory names returned by the `ls` command.

See ["Keyboard backlight" Section 1.1 sysfs](https://wiki.archlinux.org/title/Keyboard_backlight#sysfs) of the ArchWiki for my reasoning behind the change.