### PR TITLE
Hyprpanel now accurately identifies the submap on startup.

### DIFF
--- a/customModules/submap/helpers.ts
+++ b/customModules/submap/helpers.ts
@@ -1,0 +1,20 @@
+import { Variable } from 'types/variable';
+
+const hyprland = await Service.import('hyprland');
+
+export const isSubmapEnabled = (submap: string, enabled: string, disabled: string): string => {
+    return submap !== 'default' ? enabled : disabled;
+};
+
+export const getInitialSubmap = (submapStatus: Variable<string>): void => {
+    let submap = hyprland.message('submap');
+
+    const newLineCarriage = /\n/g;
+    submap = submap.replace(newLineCarriage, '');
+
+    if (submap === 'unknown request') {
+        submap = 'default';
+    }
+
+    submapStatus.value = submap;
+};

--- a/customModules/submap/index.ts
+++ b/customModules/submap/index.ts
@@ -8,6 +8,7 @@ import { Variable as VariableType } from 'types/variable';
 import { Attribute, Child } from 'lib/types/widget';
 import { BarBoxChild } from 'lib/types/bar';
 import { capitalizeFirstLetter } from 'lib/utils';
+import { getInitialSubmap, isSubmapEnabled } from './helpers';
 
 const {
     label,
@@ -33,27 +34,14 @@ hyprland.connect('submap', (_, currentSubmap) => {
     }
 });
 
-const getInitialSubmap = (): void => {
-    let submap = hyprland.message('submap');
-
-    const newLineCarriage = /\n/g;
-    submap = submap.replace(newLineCarriage, '');
-
-    if (submap === 'unknown request') {
-        submap = 'default';
-    }
-
-    submapStatus.value = submap;
-};
-
-getInitialSubmap();
+getInitialSubmap(submapStatus);
 
 export const Submap = (): BarBoxChild => {
     const submapModule = module({
         textIcon: Utils.merge(
             [submapStatus.bind('value'), enabledIcon.bind('value'), disabledIcon.bind('value')],
             (status, enabled, disabled) => {
-                return status !== 'default' ? enabled : disabled;
+                return isSubmapEnabled(status, enabled, disabled);
             },
         ),
         tooltipText: Utils.merge(
@@ -67,7 +55,7 @@ export const Submap = (): BarBoxChild => {
                 if (showSmName) {
                     return capitalizeFirstLetter(status);
                 }
-                return status !== 'default' ? enabled : disabled;
+                return isSubmapEnabled(status, enabled, disabled);
             },
         ),
         boxClass: 'submap',
@@ -82,7 +70,7 @@ export const Submap = (): BarBoxChild => {
                 if (showSmName) {
                     return capitalizeFirstLetter(status);
                 }
-                return status !== 'default' ? enabled : disabled;
+                return isSubmapEnabled(status, enabled, disabled);
             },
         ),
         showLabelBinding: label.bind('value'),

--- a/customModules/submap/index.ts
+++ b/customModules/submap/index.ts
@@ -7,7 +7,7 @@ import Button from 'types/widgets/button';
 import { Variable as VariableType } from 'types/variable';
 import { Attribute, Child } from 'lib/types/widget';
 import { BarBoxChild } from 'lib/types/bar';
-import { caapitalizeFirstLetter } from 'lib/utils';
+import { capitalizeFirstLetter } from 'lib/utils';
 
 const {
     label,
@@ -23,10 +23,14 @@ const {
     scrollDown,
 } = options.bar.customModules.submap;
 
-const submapStatus: VariableType<string> = Variable('');
+const submapStatus: VariableType<string> = Variable('default');
 
 hyprland.connect('submap', (_, currentSubmap) => {
-    submapStatus.value = currentSubmap;
+    if (currentSubmap.length === 0) {
+        submapStatus.value = 'default';
+    } else {
+        submapStatus.value = currentSubmap;
+    }
 });
 
 const getInitialSubmap = (): void => {
@@ -35,7 +39,11 @@ const getInitialSubmap = (): void => {
     const newLineCarriage = /\n/g;
     submap = submap.replace(newLineCarriage, '');
 
-    submapStatus.value = submap && submap === 'default' ? '' : submap;
+    if (submap === 'unknown request') {
+        submap = 'default';
+    }
+
+    submapStatus.value = submap;
 };
 
 getInitialSubmap();
@@ -45,7 +53,7 @@ export const Submap = (): BarBoxChild => {
         textIcon: Utils.merge(
             [submapStatus.bind('value'), enabledIcon.bind('value'), disabledIcon.bind('value')],
             (status, enabled, disabled) => {
-                return status.length > 0 ? enabled : disabled;
+                return status !== 'default' ? enabled : disabled;
             },
         ),
         tooltipText: Utils.merge(
@@ -57,9 +65,9 @@ export const Submap = (): BarBoxChild => {
             ],
             (status, enabled, disabled, showSmName) => {
                 if (showSmName) {
-                    return status.length > 0 ? caapitalizeFirstLetter(status) : 'Default';
+                    return capitalizeFirstLetter(status);
                 }
-                return status.length > 0 ? enabled : disabled;
+                return status !== 'default' ? enabled : disabled;
             },
         ),
         boxClass: 'submap',
@@ -72,9 +80,9 @@ export const Submap = (): BarBoxChild => {
             ],
             (status, enabled, disabled, showSmName) => {
                 if (showSmName) {
-                    return status.length > 0 ? caapitalizeFirstLetter(status) : 'Default';
+                    return capitalizeFirstLetter(status);
                 }
-                return status.length > 0 ? enabled : disabled;
+                return status !== 'default' ? enabled : disabled;
             },
         ),
         showLabelBinding: label.bind('value'),

--- a/customModules/submap/index.ts
+++ b/customModules/submap/index.ts
@@ -29,6 +29,17 @@ hyprland.connect('submap', (_, currentSubmap) => {
     submapStatus.value = currentSubmap;
 });
 
+const getInitialSubmap = (): void => {
+    let submap = hyprland.message('submap');
+
+    const newLineCarriage = /\n/g;
+    submap = submap.replace(newLineCarriage, '');
+
+    submapStatus.value = submap && submap === 'default' ? '' : submap;
+};
+
+getInitialSubmap();
+
 export const Submap = (): BarBoxChild => {
     const submapModule = module({
         textIcon: Utils.merge(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -190,6 +190,6 @@ export const isValidGjsColor = (color: string): boolean => {
     return false;
 };
 
-export const caapitalizeFirstLetter = (str: string): string => {
+export const capitalizeFirstLetter = (str: string): string => {
     return str.charAt(0).toUpperCase() + str.slice(1);
 };


### PR DESCRIPTION
Previously, the submap would have to change at least once as it was identified on an event change. Meaning that an event would have to be triggered before it was syncronized with the panel. This would cause scenarios in which you would start Hyprpanel with a submap on but it would label it inaccurately as 'Default'.

With a new Hyprland update `0.44.0` the `hyprctl` can return a submap. We query this submap on startup to determine the initial submap value which now displays the correct submap on hyprpanel launch.

I'm saying 'submap' too much.