### PR TITLE
fix: hide pager when only first page

### DIFF
--- a/modules/menus/notifications/pager/index.ts
+++ b/modules/menus/notifications/pager/index.ts
@@ -5,7 +5,6 @@ import options from 'options';
 import { Notification } from 'types/service/notifications';
 import { Variable } from 'types/variable';
 
-
 const { displayedTotal } = options.notifications;
 const { show: showPager } = options.theme.bar.menus.menu.notifications.pager;
 

--- a/modules/menus/notifications/pager/index.ts
+++ b/modules/menus/notifications/pager/index.ts
@@ -5,6 +5,7 @@ import options from 'options';
 import { Notification } from 'types/service/notifications';
 import { Variable } from 'types/variable';
 
+
 const { displayedTotal } = options.notifications;
 const { show: showPager } = options.theme.bar.menus.menu.notifications.pager;
 
@@ -21,7 +22,7 @@ export const NotificationPager = (curPage: Variable<number>): BoxWidget => {
                 showPager.bind('value'),
             ],
             (currentPage: number, dispTotal: number, _: Notification[], showPgr: boolean) => {
-                if (showPgr === false) {
+                if (showPgr === false || (currentPage === 1 && notifs.notifications.length <= dispTotal)) {
                     return [];
                 }
                 return [


### PR DESCRIPTION
Hide the page when there are only one page



when 0 notifications == no pager
![image](https://github.com/user-attachments/assets/d6452438-1185-4dc9-aca9-b8bec02011c3)

when has only first page === no pager
![image](https://github.com/user-attachments/assets/48d32538-2787-4233-9253-35dd2687343d)

when there is more than one pages === pager
![image](https://github.com/user-attachments/assets/9e780c32-5186-4412-907c-81be0ccae575)



closes https://github.com/Jas-SinghFSU/HyprPanel/issues/314