### PR TITLE
feature: remove delay when clearing all notifications

### DIFF
--- a/globals/notification.ts
+++ b/globals/notification.ts
@@ -25,11 +25,11 @@ export const getNotificationIcon = (app_name: string, app_icon: string, app_entr
     return icon;
 };
 
-export const closeNotifications = async (notifications: Notification[]): Promise<void> => {
+export const closeNotifications = async (notifications: Notification[], delay: number): Promise<void> => {
     removingNotifications.value = true;
     for (const notif of notifications) {
         notif.close();
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
     removingNotifications.value = false;
 };

--- a/modules/menus/notifications/controls/index.ts
+++ b/modules/menus/notifications/controls/index.ts
@@ -1,6 +1,9 @@
 import { closeNotifications } from 'globals/notification';
 import { BoxWidget } from 'lib/types/widget';
 import { Notifications } from 'types/service/notifications';
+import options from 'options';
+
+const { clearDelay } = options.notifications;
 
 const Controls = (notifs: Notifications): BoxWidget => {
     return Widget.Box({
@@ -44,13 +47,15 @@ const Controls = (notifs: Notifications): BoxWidget => {
                             Widget.Button({
                                 className: 'clear-notifications-button',
                                 tooltip_text: 'Clear Notifications',
-                                on_primary_click: () => {
-                                    if (removingNotifications.value) {
-                                        return;
-                                    }
+                                on_primary_click: clearDelay.bind('value').as((delay) => {
+                                    return () => {
+                                        if (removingNotifications.value) {
+                                            return;
+                                        }
 
-                                    closeNotifications(notifs.notifications);
-                                },
+                                        return closeNotifications(notifs.notifications, delay);
+                                    };
+                                }),
                                 child: Widget.Label({
                                     class_name: removingNotifications.bind('value').as((removing: boolean) => {
                                         return removing

--- a/options.ts
+++ b/options.ts
@@ -1170,6 +1170,7 @@ const options = mkOptions(OPTIONS, {
         active_monitor: opt(true),
         timeout: opt(7000),
         cache_actions: opt(true),
+        clearDelay: opt(100),
     },
 
     dummy: opt(true),

--- a/widget/settings/pages/config/notifications/index.ts
+++ b/widget/settings/pages/config/notifications/index.ts
@@ -48,7 +48,9 @@ export const NotificationSettings = (): Scrollable<Child, Attribute> => {
                 Option({
                     opt: options.notifications.clearDelay,
                     title: 'Clear Delay',
-                    subtitle: 'The delay in milliseconds before a notification is cleared',
+                    subtitle:
+                        'The delay in milliseconds before a notification is cleared' +
+                        '\nWARNING: Setting this value too low may crash AGS depending on your system.',
                     type: 'number',
                     increment: 20,
 

--- a/widget/settings/pages/config/notifications/index.ts
+++ b/widget/settings/pages/config/notifications/index.ts
@@ -53,7 +53,6 @@ export const NotificationSettings = (): Scrollable<Child, Attribute> => {
                         '\nWARNING: Setting this value too low may crash AGS depending on your system.',
                     type: 'number',
                     increment: 20,
-
                 }),
                 Option({
                     opt: options.notifications.timeout,

--- a/widget/settings/pages/config/notifications/index.ts
+++ b/widget/settings/pages/config/notifications/index.ts
@@ -50,6 +50,8 @@ export const NotificationSettings = (): Scrollable<Child, Attribute> => {
                     title: 'Clear Delay',
                     subtitle: 'The delay in milliseconds before a notification is cleared',
                     type: 'number',
+                    increment: 20,
+
                 }),
                 Option({
                     opt: options.notifications.timeout,

--- a/widget/settings/pages/config/notifications/index.ts
+++ b/widget/settings/pages/config/notifications/index.ts
@@ -46,6 +46,12 @@ export const NotificationSettings = (): Scrollable<Child, Attribute> => {
                     type: 'boolean',
                 }),
                 Option({
+                    opt: options.notifications.clearDelay,
+                    title: 'Clear Delay',
+                    subtitle: 'The delay in milliseconds before a notification is cleared',
+                    type: 'number',
+                }),
+                Option({
                     opt: options.notifications.timeout,
                     title: 'Notification Timeout',
                     subtitle: 'How long notification popups will last (in milliseconds).',


### PR DESCRIPTION
When having 50+ notifications, clicking the clear all button takes some time before it does the job.

This was because we were adding a delay with settimeout of 100 ms . 
This makes the clearall instant which is a better UX similar to other implementations like in `swaync`