### PR TITLE
feat: add option to hide seconds on calendar

### DIFF
--- a/modules/menus/calendar/time/index.ts
+++ b/modules/menus/calendar/time/index.ts
@@ -1,7 +1,7 @@
 import { BoxWidget } from 'lib/types/widget';
 import options from 'options';
 
-const { military } = options.menus.clock.time;
+const { military, hideSeconds } = options.menus.clock.time;
 
 const time = Variable('', {
     poll: [1000, 'date "+%I:%M:%S"'],
@@ -26,43 +26,48 @@ const TimeWidget = (): BoxWidget => {
             vpack: 'center',
             hpack: 'center',
             class_name: 'clock-content-items',
-            children: military.bind('value').as((is24hr) => {
-                if (!is24hr) {
+            children: Utils.merge(
+                [military.bind('value'), hideSeconds.bind('value')],
+                (is24hr: boolean, hideSeconds: boolean) => {
+                    if (!is24hr) {
+                        return [
+                            Widget.Box({
+                                hpack: 'center',
+                                children: [
+                                    Widget.Label({
+                                        class_name: 'clock-content-time',
+                                        label: hideSeconds ? time.bind().as((str) => str.slice(0, -3)) : time.bind(),
+                                    }),
+                                ],
+                            }),
+                            Widget.Box({
+                                hpack: 'center',
+                                children: [
+                                    Widget.Label({
+                                        vpack: 'end',
+                                        class_name: 'clock-content-period',
+                                        label: period.bind(),
+                                    }),
+                                ],
+                            }),
+                        ];
+                    }
+
                     return [
                         Widget.Box({
                             hpack: 'center',
                             children: [
                                 Widget.Label({
                                     class_name: 'clock-content-time',
-                                    label: time.bind(),
-                                }),
-                            ],
-                        }),
-                        Widget.Box({
-                            hpack: 'center',
-                            children: [
-                                Widget.Label({
-                                    vpack: 'end',
-                                    class_name: 'clock-content-period',
-                                    label: period.bind(),
+                                    label: hideSeconds
+                                        ? militaryTime.bind().as((str) => str.slice(0, -3))
+                                        : militaryTime.bind(),
                                 }),
                             ],
                         }),
                     ];
-                }
-
-                return [
-                    Widget.Box({
-                        hpack: 'center',
-                        children: [
-                            Widget.Label({
-                                class_name: 'clock-content-time',
-                                label: militaryTime.bind(),
-                            }),
-                        ],
-                    }),
-                ];
-            }),
+                },
+            ),
         }),
     });
 };

--- a/options.ts
+++ b/options.ts
@@ -1137,6 +1137,7 @@ const options = mkOptions(OPTIONS, {
         clock: {
             time: {
                 military: opt(false),
+                hideSeconds: opt(false),
             },
             weather: {
                 enabled: opt(true),

--- a/widget/settings/pages/config/menus/clock.ts
+++ b/widget/settings/pages/config/menus/clock.ts
@@ -14,6 +14,7 @@ export const ClockMenuSettings = (): Scrollable<Child, Attribute> => {
             children: [
                 Header('Time'),
                 Option({ opt: options.menus.clock.time.military, title: 'Use 24hr time', type: 'boolean' }),
+                Option({ opt: options.menus.clock.time.hideSeconds, title: 'Hide seconds', type: 'boolean' }),
 
                 Header('Weather'),
                 Option({ opt: options.menus.clock.weather.enabled, title: 'Enabled', type: 'boolean' }),


### PR DESCRIPTION
Allow option to hide seconds on calendar, backward compatible as false is the default value



![image](https://github.com/user-attachments/assets/31f09514-73d7-4a3b-9995-f2dd2b60d083)

![image](https://github.com/user-attachments/assets/17682f16-f0a9-48ad-9d92-5e80f78ee3fc)
