### PR TITLE
fix: make image bigger on notification card

### DIFF
--- a/scss/style/notifications/popups.scss
+++ b/scss/style/notifications/popups.scss
@@ -24,8 +24,8 @@
 
 .notification-card-image {
   border-radius: 0.4em;
-  min-width: 1.5em;
-  min-height: 1.5em;
+  min-width: 2.5em;
+  min-height: 2.5em;
   padding: 0.85em 0.85em;
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
Makes the image a lil bigger so it looks nicer

Before:
![image](https://github.com/user-attachments/assets/5368f293-0b5e-484c-a1f8-c3105560f18a)

After:
![image](https://github.com/user-attachments/assets/7c5ee73a-ac4e-4207-b278-c7188df7a5f2)



