### PR TITLE
fix: make bottom padding consistent for dashboard

### DIFF
--- a/scss/style/menus/dashboard.scss
+++ b/scss/style/menus/dashboard.scss
@@ -9,6 +9,7 @@
   border: $bar-menus-border-size solid if($bar-menus-monochrome, $bar-menus-border-color, $bar-menus-menu-dashboard-border-color);
   border-radius: $bar-menus-border-radius;
   opacity: $bar-menus-opacity * 0.01;
+  padding-bottom: 0.75em;
 
   button {
     border-radius: 0.4em;


### PR DESCRIPTION
when disabling the sections  on dashboard , the bottom padding is also gone

![image](https://github.com/user-attachments/assets/3714bc99-10e9-4baa-b159-31ec12fc40d0)

this makes the padding consistent across the disable operations of sections in dashboard


![image](https://github.com/user-attachments/assets/a28089b4-0634-4c6a-99e8-cd80503a7c0e)
