### PR TITLE
feat: use .face.icon

### DIFF
--- a/lib/icons.ts
+++ b/lib/icons.ts
@@ -41,7 +41,6 @@ export default {
         time: 'hourglass-symbolic',
         toolbars: 'toolbars-symbolic',
         warning: 'dialog-warning-symbolic',
-        avatar: 'avatar-default-symbolic',
         arrow: {
             right: 'pan-end-symbolic',
             left: 'pan-start-symbolic',

--- a/modules/icons/index.ts
+++ b/modules/icons/index.ts
@@ -41,7 +41,6 @@ export default {
         time: 'hourglass-symbolic',
         toolbars: 'toolbars-symbolic',
         warning: 'dialog-warning-symbolic',
-        avatar: 'avatar-default-symbolic',
         arrow: {
             right: 'pan-end-symbolic',
             left: 'pan-start-symbolic',

--- a/options.ts
+++ b/options.ts
@@ -1066,7 +1066,7 @@ const options = mkOptions(OPTIONS, {
                 logout: opt('hyprctl dispatch exit'),
                 shutdown: opt('systemctl poweroff'),
                 avatar: {
-                    image: opt('avatar-default-symbolic'),
+                    image: opt('$HOME/.face.icon'),
                     name: opt<'system' | string>('system'),
                 },
             },

--- a/widget/settings/pages/config/menus/dashboard.ts
+++ b/widget/settings/pages/config/menus/dashboard.ts
@@ -16,7 +16,12 @@ export const DashboardMenuSettings = (): Scrollable<Child, Attribute> => {
             vertical: true,
             children: [
                 Header('Power Menu'),
-                Option({ opt: options.menus.dashboard.powermenu.avatar.image, title: 'Profile Image', type: 'img' }),
+                Option({
+                    opt: options.menus.dashboard.powermenu.avatar.image,
+                    title: 'Profile Image',
+                    type: 'img',
+                    subtitle: "By default, uses '~/.face.icon'",
+                }),
                 Option({
                     opt: options.menus.dashboard.powermenu.avatar.name,
                     title: 'Profile Name',


### PR DESCRIPTION
when the `~/.face.icon`, doesnt exits, show hyperpanel logo

![image](https://github.com/user-attachments/assets/cabdbf9c-20fd-45db-a015-dd24b25343b3)


when it does exits, show it instead


![image](https://github.com/user-attachments/assets/058ee2ae-69ab-49d6-bb24-53c834e88dab)



Also the `avatar-default-symbolic` does not exist which we were using as default

![image](https://github.com/user-attachments/assets/d144e1c9-52c7-4f4c-841f-673642c07c76)


 More context: https://askubuntu.com/questions/114060/what-is-face-binary
closes https://github.com/Jas-SinghFSU/HyprPanel/issues/359