### PR TITLE
fix: dont hardcode file manager and make use of $TERM

### DIFF
--- a/modules/menus/dashboard/stats/index.ts
+++ b/modules/menus/dashboard/stats/index.ts
@@ -24,7 +24,7 @@ interval.connect('changed', () => {
 
 const handleClick = (): void => {
     App.closeWindow('dashboardmenu');
-    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch((err) => `Failed to open btop: ${err}`);
+    Utils.execAsync(`bash -c "${terminal} -e btop"`).catch((err) => `Failed to open btop: ${err}`);
 };
 
 const Stats = (): BoxWidget => {

--- a/modules/menus/dashboard/stats/index.ts
+++ b/modules/menus/dashboard/stats/index.ts
@@ -7,6 +7,7 @@ import Cpu from 'services/Cpu';
 import Storage from 'services/Storage';
 import { renderResourceLabel } from 'customModules/utils';
 
+const { terminal } = options;
 const { enable_gpu, interval } = options.menus.dashboard.stats;
 
 const ramService = new Ram();

--- a/modules/menus/dashboard/stats/index.ts
+++ b/modules/menus/dashboard/stats/index.ts
@@ -7,7 +7,6 @@ import Cpu from 'services/Cpu';
 import Storage from 'services/Storage';
 import { renderResourceLabel } from 'customModules/utils';
 
-const { terminal } = options;
 const { enable_gpu, interval } = options.menus.dashboard.stats;
 
 const ramService = new Ram();
@@ -22,6 +21,12 @@ interval.connect('changed', () => {
     cpuService.updateTimer(interval.value);
     storageService.updateTimer(interval.value);
 });
+
+
+const handleClick = (): void => {
+    App.closeWindow('dashboardmenu');
+    Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch((err) => `Failed to open btop: ${err}`);
+};
 
 const Stats = (): BoxWidget => {
     const divide = ([total, free]: number[]): number => free / total;
@@ -82,28 +87,18 @@ const Stats = (): BoxWidget => {
 
                                 return (self.children = [
                                     Widget.Button({
-                                        on_primary_click: terminal.bind('value').as((term) => {
-                                            return (): void => {
-                                                App.closeWindow('dashboardmenu');
-                                                Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                                    (err) => `Failed to open btop: ${err}`,
-                                                );
-                                            };
-                                        }),
+                                        on_primary_click: () => {
+                                            handleClick();
+                                        },
                                         child: Widget.Label({
                                             class_name: 'txt-icon',
                                             label: '󰢮',
                                         }),
                                     }),
                                     Widget.Button({
-                                        on_primary_click: terminal.bind('value').as((term) => {
-                                            return (): void => {
-                                                App.closeWindow('dashboardmenu');
-                                                Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                                    (err) => `Failed to open btop: ${err}`,
-                                                );
-                                            };
-                                        }),
+                                        on_primary_click: () => {
+                                            handleClick();
+                                        },
                                         child: Widget.LevelBar({
                                             class_name: 'stats-bar',
                                             hexpand: true,
@@ -150,28 +145,18 @@ const Stats = (): BoxWidget => {
                         vpack: 'center',
                         children: [
                             Widget.Button({
-                                on_primary_click: terminal.bind('value').as((term) => {
-                                    return () => {
-                                        App.closeWindow('dashboardmenu');
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    };
-                                }),
+                                on_primary_click: () => {
+                                    handleClick();
+                                },
                                 child: Widget.Label({
                                     class_name: 'txt-icon',
                                     label: '',
                                 }),
                             }),
                             Widget.Button({
-                                on_primary_click: terminal.bind('value').as((term) => {
-                                    return () => {
-                                        App.closeWindow('dashboardmenu');
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    };
-                                }),
+                                on_primary_click: () => {
+                                    handleClick();
+                                },
                                 child: Widget.LevelBar({
                                     class_name: 'stats-bar',
                                     hexpand: true,
@@ -199,28 +184,18 @@ const Stats = (): BoxWidget => {
                         hexpand: true,
                         children: [
                             Widget.Button({
-                                on_primary_click: terminal.bind('value').as((term) => {
-                                    return () => {
-                                        App.closeWindow('dashboardmenu');
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    };
-                                }),
+                                on_primary_click: () => {
+                                    handleClick();
+                                },
                                 child: Widget.Label({
                                     class_name: 'txt-icon',
                                     label: '',
                                 }),
                             }),
                             Widget.Button({
-                                on_primary_click: terminal.bind('value').as((term) => {
-                                    return () => {
-                                        App.closeWindow('dashboardmenu');
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    };
-                                }),
+                                on_primary_click: () => {
+                                    handleClick();
+                                },
                                 child: Widget.LevelBar({
                                     class_name: 'stats-bar',
                                     hexpand: true,
@@ -251,28 +226,18 @@ const Stats = (): BoxWidget => {
                         vpack: 'center',
                         children: [
                             Widget.Button({
-                                on_primary_click: terminal.bind('value').as((term) => {
-                                    return () => {
-                                        App.closeWindow('dashboardmenu');
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    };
-                                }),
+                                on_primary_click: () => {
+                                    handleClick();
+                                },
                                 child: Widget.Label({
                                     class_name: 'txt-icon',
                                     label: '󰋊',
                                 }),
                             }),
                             Widget.Button({
-                                on_primary_click: terminal.bind('value').as((term) => {
-                                    return () => {
-                                        App.closeWindow('dashboardmenu');
-                                        Utils.execAsync(`bash -c "${term} -e btop"`).catch(
-                                            (err) => `Failed to open btop: ${err}`,
-                                        );
-                                    };
-                                }),
+                                on_primary_click: () => {
+                                    handleClick();
+                                },
                                 child: Widget.LevelBar({
                                     class_name: 'stats-bar',
                                     hexpand: true,

--- a/modules/menus/dashboard/stats/index.ts
+++ b/modules/menus/dashboard/stats/index.ts
@@ -22,7 +22,6 @@ interval.connect('changed', () => {
     storageService.updateTimer(interval.value);
 });
 
-
 const handleClick = (): void => {
     App.closeWindow('dashboardmenu');
     Utils.execAsync(`bash -c "$TERMINAL -e btop"`).catch((err) => `Failed to open btop: ${err}`);

--- a/options.ts
+++ b/options.ts
@@ -1160,6 +1160,8 @@ const options = mkOptions(OPTIONS, {
 
     scalingPriority: opt<ScalingPriority>('gdk'),
 
+    terminal: opt('$TERMINAL'),
+    
     tear: opt(false),
 
     wallpaper: {

--- a/options.ts
+++ b/options.ts
@@ -1160,8 +1160,7 @@ const options = mkOptions(OPTIONS, {
 
     scalingPriority: opt<ScalingPriority>('gdk'),
 
-    terminal: opt('$TERMINAL'),
-    
+    terminal: opt('$TERM'),
     tear: opt(false),
 
     wallpaper: {

--- a/options.ts
+++ b/options.ts
@@ -1114,29 +1114,29 @@ const options = mkOptions(OPTIONS, {
                 left: {
                     directory1: {
                         label: opt('󰉍 Downloads'),
-                        command: opt('bash -c "dolphin $HOME/Downloads/"'),
+                        command: opt('bash -c "xdg-open $HOME/Downloads/"'),
                     },
                     directory2: {
                         label: opt('󰉏 Videos'),
-                        command: opt('bash -c "dolphin $HOME/Videos/"'),
+                        command: opt('bash -c "xdg-open $HOME/Videos/"'),
                     },
                     directory3: {
                         label: opt('󰚝 Projects'),
-                        command: opt('bash -c "dolphin $HOME/Projects/"'),
+                        command: opt('bash -c "xdg-open $HOME/Projects/"'),
                     },
                 },
                 right: {
                     directory1: {
                         label: opt('󱧶 Documents'),
-                        command: opt('bash -c "dolphin $HOME/Documents/"'),
+                        command: opt('bash -c "xdg-open $HOME/Documents/"'),
                     },
                     directory2: {
                         label: opt('󰉏 Pictures'),
-                        command: opt('bash -c "dolphin $HOME/Pictures/"'),
+                        command: opt('bash -c "xdg-open $HOME/Pictures/"'),
                     },
                     directory3: {
                         label: opt('󱂵 Home'),
-                        command: opt('bash -c "dolphin $HOME/"'),
+                        command: opt('bash -c "xdg-open $HOME/"'),
                     },
                 },
             },
@@ -1159,8 +1159,6 @@ const options = mkOptions(OPTIONS, {
     },
 
     scalingPriority: opt<ScalingPriority>('gdk'),
-
-    terminal: opt('kitty'),
 
     tear: opt(false),
 

--- a/widget/settings/pages/config/general/index.ts
+++ b/widget/settings/pages/config/general/index.ts
@@ -35,12 +35,6 @@ export const BarGeneral = (): Scrollable<Child, Attribute> => {
                     },
                 }),
                 Option({
-                    opt: options.terminal,
-                    title: 'Terminal',
-                    subtitle: "Tools such as 'btop' will open in this terminal",
-                    type: 'string',
-                }),
-                Option({
                     opt: options.tear,
                     title: 'Tearing Compatible',
                     subtitle:

--- a/widget/settings/pages/config/general/index.ts
+++ b/widget/settings/pages/config/general/index.ts
@@ -35,6 +35,12 @@ export const BarGeneral = (): Scrollable<Child, Attribute> => {
                     },
                 }),
                 Option({
+                    opt: options.terminal,
+                    title: 'Terminal',
+                    subtitle: "Tools such as 'btop' will open in this terminal",
+                    type: 'string',
+                }),
+                Option({
                     opt: options.tear,
                     title: 'Tearing Compatible',
                     subtitle:


### PR DESCRIPTION
With this, user can use any file manager they have setup.
This also removes terminal and uses the one setup on $TERM varibale. The original PR contains a mistake as TERM env is used instead of TERMINAL

https://www.ibm.com/docs/en/informix-servers/14.10?topic=products-term-environment-variable-unix
https://bash.cyberciti.biz/guide/$TERM_variable

closes https://github.com/Jas-SinghFSU/HyprPanel/pull/156