### PR TITLE
Fix recording script to terminate properly.

### DIFF
--- a/services/screen_record.sh
+++ b/services/screen_record.sh
@@ -32,7 +32,6 @@ startRecording() {
     gpu-screen-recorder \
         -w "$target" \
         -f 60 \
-        -fm cfr \
         -k h264 \
         -a "$(pactl get-default-sink).monitor" \
         -o "$outputPath" \

--- a/services/screen_record.sh
+++ b/services/screen_record.sh
@@ -26,10 +26,17 @@ startRecording() {
         echo "Usage: $0 start screen [screen_name]"
         exit 1
     fi
-    
-    GPU_TYPE=$(lspci | grep -E 'VGA|3D' | grep -Ev '00:02.0|Integrated' > /dev/null && echo "" || echo "-encoder cpu")
 
-    gpu-screen-recorder -w "$target" -f 60 -a "$(pactl get-default-sink).monitor" -o "$outputPath" $GPU_TYPE &
+    GPU_TYPE=$(lspci | grep -E 'VGA|3D' | grep -Ev '00:02.0|Integrated' >/dev/null && echo "" || echo "-encoder cpu")
+
+    gpu-screen-recorder \
+        -w "$target" \
+        -f 60 \
+        -fm cfr \
+        -k h264 \
+        -a "$(pactl get-default-sink).monitor" \
+        -o "$outputPath" \
+        $GPU_TYPE &
 
     echo "Recording started. Output will be saved to $outputPath"
 }
@@ -40,8 +47,10 @@ stopRecording() {
         exit 1
     fi
 
-    pkill -f gpu-screen-recorder
+    pkill -SIGINT -f gpu-screen-recorder
+
     recentFile=$(ls -t "$outputDir"/recording_*.mp4 | head -n 1)
+
     notify-send "Recording stopped" "Your recording has been saved." \
         -i video-x-generic \
         -a "Screen Recorder" \


### PR DESCRIPTION
Pkill -f was killing the recorder improperly causing the final recording to not be initialized. Which would then cause issues when attempting to play the file back. This new script now terminates the recording with -SIGINT to prevent that issue.