### PR TITLE
fix: wifi menu scrollable

### DIFF
--- a/modules/menus/network/wifi/index.ts
+++ b/modules/menus/network/wifi/index.ts
@@ -56,7 +56,7 @@ const Wifi = (): BoxWidget => {
                 ],
             }),
             Widget.Scrollable({
-                css: "min-height: 300px;",
+                css: 'min-height: 300px;',
                 child: Widget.Box({
                     class_name: 'menu-items-section',
                     vertical: true,
@@ -76,7 +76,7 @@ const Wifi = (): BoxWidget => {
                         }),
                     ],
                 }),
-            })
+            }),
         ],
     });
 };

--- a/modules/menus/network/wifi/index.ts
+++ b/modules/menus/network/wifi/index.ts
@@ -55,25 +55,28 @@ const Wifi = (): BoxWidget => {
                     }),
                 ],
             }),
-            Widget.Box({
-                class_name: 'menu-items-section',
-                vertical: true,
-                children: [
-                    Widget.Box({
-                        class_name: 'wap-staging',
-                        setup: (self) => {
-                            renderWapStaging(self, network, Staging, Connecting);
-                        },
-                    }),
-                    Widget.Box({
-                        class_name: 'available-waps',
-                        vertical: true,
-                        setup: (self) => {
-                            renderWAPs(self, network, Staging, Connecting);
-                        },
-                    }),
-                ],
-            }),
+            Widget.Scrollable({
+                css: "min-height: 300px;",
+                child: Widget.Box({
+                    class_name: 'menu-items-section',
+                    vertical: true,
+                    children: [
+                        Widget.Box({
+                            class_name: 'wap-staging',
+                            setup: (self) => {
+                                renderWapStaging(self, network, Staging, Connecting);
+                            },
+                        }),
+                        Widget.Box({
+                            class_name: 'available-waps',
+                            vertical: true,
+                            setup: (self) => {
+                                renderWAPs(self, network, Staging, Connecting);
+                            },
+                        }),
+                    ],
+                }),
+            })
         ],
     });
 };


### PR DESCRIPTION
before the pr, the wifi menu would stretch which would could cause the menu to fill the entire vertical width if there were 15-20 + wifis
![image](https://github.com/user-attachments/assets/c8d5718a-7dd6-4091-a964-f7c6cd42b3aa)


The menu is made a scrollable so it has a constant height irrespective of how many networks are available
[Kooha-2024-11-08-09-07-42.webm](https://github.com/user-attachments/assets/648fff46-606e-47a0-a0a6-85c18e0ae43d)
