### PR TITLE
feat(media): truncate media label with consideration of full-width characters

### DIFF
--- a/modules/bar/media/helpers.ts
+++ b/modules/bar/media/helpers.ts
@@ -39,6 +39,30 @@ const isValidMediaTag = (tag: unknown): tag is keyof MediaTags => {
     return (mediaTagKeys as readonly string[]).includes(tag);
 };
 
+const fullWidthRegex = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\uFF00-\uFFEF]/u;
+
+const truncateByLength = (str: string, maxLength: number): string => {
+    if (maxLength <= 0) {
+        return str;
+    }
+
+    let length = 0;
+    let isTruncated = false;
+    let truncatedStr = '';
+
+    for (const char of str) {
+        length += fullWidthRegex.test(char) ? 2 : 1;
+
+        if (length > maxLength) {
+            isTruncated = true;
+            break;
+        }
+        truncatedStr += char;
+    }
+
+    return isTruncated ? truncatedStr + '...' : str;
+};
+
 export const generateMediaLabel = (
     truncation_size: Opt<number>,
     show_label: Opt<boolean>,
@@ -75,11 +99,7 @@ export const generateMediaLabel = (
 
         const maxLabelSize = truncation_size.value;
 
-        let mediaLabel = truncatedLabel;
-
-        if (maxLabelSize > 0 && truncatedLabel.length > maxLabelSize) {
-            mediaLabel = `${truncatedLabel.substring(0, maxLabelSize)}...`;
-        }
+        let mediaLabel = truncateByLength(truncatedLabel, maxLabelSize);
 
         return mediaLabel.length ? mediaLabel : 'Media';
     } else {


### PR DESCRIPTION
Previously, all characters were treated as 1 unit wide, which caused incorrect truncation for certain characters, such as CJK characters. This resulted in media labels being longer than expected when compared to ASCII characters.

For instance, when the "Media - Truncation Size" is set to 30, the truncation works correctly for alphabetic characters, displaying up to 30 characters. However, for CJK characters, each character was counted as 1 unit, causing the truncation to display approximately twice the width compared to 30 alphabetic characters.

This commit introduces a Regex solution to count full-width characters as 2 units in length. While this approach may not cover every possible full-width character, it should be sufficient for most common scenarios.