### PR TITLE
Fix: Replace deprecated 'gnome.gnome-bluetooth'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
               pkgsFor.${system}.grimblast
               pkgsFor.${system}.gpu-screen-recorder
               pkgsFor.${system}.brightnessctl
-              pkgsFor.${system}.gnome.gnome-bluetooth
+              pkgsFor.${system}.gnome-bluetooth
               pkgsFor.${system}.python3
               pkgsFor.${system}.matugen
               inputs.ags.packages.${system}.agsWithTypes

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -56,7 +56,7 @@ in {
   desktop = {
     inherit config;
     script = writeShellScriptBin pname ''
-      export PATH=$PATH:${lib.makeBinPath [dart-sass fd btop pipewire bluez bluez-tools networkmanager matugen swww grimblast gpu-screen-recorder brightnessctl pkgs.gnome.gnome-bluetooth python3]}
+      export PATH=$PATH:${lib.makeBinPath [dart-sass fd btop pipewire bluez bluez-tools networkmanager matugen swww grimblast gpu-screen-recorder brightnessctl pkgs.gnome-bluetooth python3]}
       export GI_TYPELIB_PATH=${libgtop}/lib/girepository-1.0:${glib}/lib/girepository-1.0:$GI_TYPELIB_PATH
       ${ags}/bin/ags -b hyprpanel -c ${config}/config.js $@
     '';


### PR DESCRIPTION
This PR fixes the deprecated reference to `gnome.gnome-bluetooth` in the`flake.nix` and  `nix/default.nix` file. 
The package has been moved to the top-level as `pkgs.gnome-bluetooth`, causing errors during builds.