### PR TITLE
Fix weather disable not working

### DIFF
--- a/src/components/menus/calendar/weather/index.tsx
+++ b/src/components/menus/calendar/weather/index.tsx
@@ -4,7 +4,11 @@ import { TodayTemperature } from './temperature/index.js';
 import { HourlyTemperature } from './hourly/index.js';
 import Separator from 'src/components/shared/Separator.js';
 
-export const WeatherWidget = (): JSX.Element => {
+export const WeatherWidget = ({ isEnabled }: WeatherWidgetProps): JSX.Element => {
+    if (!isEnabled) {
+        return <box />;
+    }
+
     return (
         <box className={'calendar-menu-item-container weather'}>
             <box className={'weather-container-box'}>
@@ -21,3 +25,7 @@ export const WeatherWidget = (): JSX.Element => {
         </box>
     );
 };
+
+interface WeatherWidgetProps {
+    isEnabled: boolean;
+}


### PR DESCRIPTION
During AGS v2 migration, this seems to have been missed, so the weather widget would always display, no matter the value of the setting

Closes #578