### PR TITLE
Properly implement low battery notification service

### DIFF
--- a/src/lib/behaviors/batteryWarning.ts
+++ b/src/lib/behaviors/batteryWarning.ts
@@ -3,8 +3,8 @@ import icons from '../icons/icons';
 import { Notify } from '../utils';
 
 export function warnOnLowBattery(): void {
-    var sentLowNotification = false;
-    var sentHalfLowNotification = false;
+    let sentLowNotification = false;
+    let sentHalfLowNotification = false;
 
     batteryService.connect('notify::charging', () => {
         // Reset it when the battery is put to charge
@@ -28,7 +28,7 @@ export function warnOnLowBattery(): void {
 
         // To avoid double notifications, we check each of the thresholds and set the correct `sentNotification`, but then
         // combine them into one notification only
-        var sendNotification = false;
+        let sendNotification = false;
         if (!sentLowNotification && batteryPercentage < lowThreshold) {
             sentLowNotification = true;
             sendNotification = true;


### PR DESCRIPTION
The original implementation had multiple issues:
1. The service itself would never trigger as it listened to be notified of the wrong variable. Should have been `percentage` not `percent`
2. `.percentage` is reported as a double between 0 and 1, so setting the threshold to a percentage representation of the threshold (20 for example) would never trigger it
3. Strict comparison of doubles would never work as the battery percentage will always be way more precise than 2 decimal points
4. The replacement of the magic value `$POWER_LEVEL` did not work at all


Instead I opted for an implementation that checks for the values bellow the threshold and send the notification if bellow that value, resetting this when the battery is reported as charging

Closes #575 