### PR TITLE
Adds options for bar workspace button shape

### DIFF
--- a/src/components/settings/pages/config/bar/index.tsx
+++ b/src/components/settings/pages/config/bar/index.tsx
@@ -147,26 +147,26 @@ export const BarSettings = (): JSX.Element => {
                     type="boolean"
                 />
                 <Option
-                    opt={options.theme.bar.buttons.workspaces.indicator.radius}
-                    title="Indicator Radius"
+                    opt={options.theme.bar.buttons.workspaces.pill.radius}
+                    title="Pill Radius"
                     subtitle="Adjust the radius for the default indicator."
                     type="string"
                 />
                 <Option
-                    opt={options.theme.bar.buttons.workspaces.indicator.height}
-                    title="Indicator Height"
+                    opt={options.theme.bar.buttons.workspaces.pill.height}
+                    title="Pill Height"
                     subtitle="Adjust the height for the default indicator."
                     type="string"
                 />
                 <Option
-                    opt={options.theme.bar.buttons.workspaces.indicator.width}
-                    title="Indicator Width"
+                    opt={options.theme.bar.buttons.workspaces.pill.width}
+                    title="Pill Width"
                     subtitle="Adjust the width for the default indicator."
                     type="string"
                 />
                 <Option
-                    opt={options.theme.bar.buttons.workspaces.indicator.active_width}
-                    title="Active Indicator Width"
+                    opt={options.theme.bar.buttons.workspaces.pill.active_width}
+                    title="Active Pill Width"
                     subtitle="Adjust the width for the active default indicator."
                     type="string"
                 />

--- a/src/components/settings/pages/config/bar/index.tsx
+++ b/src/components/settings/pages/config/bar/index.tsx
@@ -152,6 +152,12 @@ export const BarSettings = (): JSX.Element => {
                     subtitle="Only applicable to numbered workspaces and mapped icons. Adjust carefully."
                     type="string"
                 />
+                <Option
+                    opt={options.theme.bar.buttons.workspaces.radius}
+                    title="Indicator Radius"
+                    subtitle="Adjust the radius for the default indicator."
+                    type="string"
+                />
                 <Option opt={options.bar.workspaces.show_icons} title="Show Workspace Icons" type="boolean" />
                 <Option opt={options.bar.workspaces.icons.available} title="Workspace Available" type="string" />
                 <Option opt={options.bar.workspaces.icons.active} title="Workspace Active" type="string" />

--- a/src/components/settings/pages/config/bar/index.tsx
+++ b/src/components/settings/pages/config/bar/index.tsx
@@ -147,15 +147,33 @@ export const BarSettings = (): JSX.Element => {
                     type="boolean"
                 />
                 <Option
-                    opt={options.theme.bar.buttons.workspaces.fontSize}
-                    title="Indicator Size"
-                    subtitle="Only applicable to numbered workspaces and mapped icons. Adjust carefully."
+                    opt={options.theme.bar.buttons.workspaces.indicator.radius}
+                    title="Indicator Radius"
+                    subtitle="Adjust the radius for the default indicator."
                     type="string"
                 />
                 <Option
-                    opt={options.theme.bar.buttons.workspaces.radius}
-                    title="Indicator Radius"
-                    subtitle="Adjust the radius for the default indicator."
+                    opt={options.theme.bar.buttons.workspaces.indicator.height}
+                    title="Indicator Height"
+                    subtitle="Adjust the height for the default indicator."
+                    type="string"
+                />
+                <Option
+                    opt={options.theme.bar.buttons.workspaces.indicator.width}
+                    title="Indicator Width"
+                    subtitle="Adjust the width for the default indicator."
+                    type="string"
+                />
+                <Option
+                    opt={options.theme.bar.buttons.workspaces.indicator.active_width}
+                    title="Active Indicator Width"
+                    subtitle="Adjust the width for the active default indicator."
+                    type="string"
+                />
+                <Option
+                    opt={options.theme.bar.buttons.workspaces.fontSize}
+                    title="Indicator Size"
+                    subtitle="Only applicable to numbered workspaces and mapped icons. Adjust carefully."
                     type="string"
                 />
                 <Option opt={options.bar.workspaces.show_icons} title="Show Workspace Icons" type="boolean" />

--- a/src/options.ts
+++ b/src/options.ts
@@ -205,6 +205,7 @@ const options = mkOptions(CONFIG, {
                     numbered_active_highlight_padding: opt('0.2em'),
                     numbered_active_highlighted_text_color: opt(colors.mantle),
                     numbered_active_underline_color: opt(colors.pink),
+                    radius: opt('1.9rem * 0.6'),
                     spacing: opt('0.5em'),
                     fontSize: opt('1.2em'),
                 },

--- a/src/options.ts
+++ b/src/options.ts
@@ -207,7 +207,7 @@ const options = mkOptions(CONFIG, {
                     numbered_active_underline_color: opt(colors.pink),
                     spacing: opt('0.5em'),
                     fontSize: opt('1.2em'),
-                    indicator: {
+                    pill: {
                         radius: opt('1.9rem * 0.6'),
                         height: opt('4em'),
                         width: opt('4em'),

--- a/src/options.ts
+++ b/src/options.ts
@@ -205,9 +205,14 @@ const options = mkOptions(CONFIG, {
                     numbered_active_highlight_padding: opt('0.2em'),
                     numbered_active_highlighted_text_color: opt(colors.mantle),
                     numbered_active_underline_color: opt(colors.pink),
-                    radius: opt('1.9rem * 0.6'),
                     spacing: opt('0.5em'),
                     fontSize: opt('1.2em'),
+                    indicator: {
+                        radius: opt('1.9rem * 0.6'),
+                        height: opt('4em'),
+                        width: opt('4em'),
+                        active_width: opt('12em'),
+                    },
                 },
                 windowtitle: {
                     background: opt(colors.base2),

--- a/src/scss/style/bar/workspace.scss
+++ b/src/scss/style/bar/workspace.scss
@@ -1,9 +1,9 @@
 .workspaces {
     label {
         font-size: 0.2em;
-        min-width: $bar-buttons-workspaces-indicator-width;
-        min-height: $bar-buttons-workspaces-indicator-height;
-        border-radius: $bar-buttons-workspaces-indicator-radius;
+        min-width: $bar-buttons-workspaces-pill-width;
+        min-height: $bar-buttons-workspaces-pill-height;
+        border-radius: $bar-buttons-workspaces-pill-radius;
         transition: 300ms * 0.5;
         background-color: $bar-buttons-workspaces-available;
         color: $bar-buttons-workspaces-available;
@@ -11,15 +11,15 @@
         &.occupied {
             background-color: $bar-buttons-workspaces-occupied;
             color: $bar-buttons-workspaces-occupied;
-            min-width: $bar-buttons-workspaces-indicator-width;
-            min-height: $bar-buttons-workspaces-indicator-height;
+            min-width: $bar-buttons-workspaces-pill-width;
+            min-height: $bar-buttons-workspaces-pill-height;
         }
 
         &.active {
             background-color: $bar-buttons-workspaces-active;
             color: $bar-buttons-workspaces-active;
-            min-width: $bar-buttons-workspaces-indicator-active_width;
-            min-height: $bar-buttons-workspaces-indicator-height;
+            min-width: $bar-buttons-workspaces-pill-active_width;
+            min-height: $bar-buttons-workspaces-pill-height;
         }
 
         &.workspace-icon {

--- a/src/scss/style/bar/workspace.scss
+++ b/src/scss/style/bar/workspace.scss
@@ -1,9 +1,9 @@
 .workspaces {
     label {
         font-size: 0.2em;
-        min-width: 4em;
-        min-height: 4em;
-        border-radius: $bar-buttons-workspaces-radius;
+        min-width: $bar-buttons-workspaces-indicator-width;
+        min-height: $bar-buttons-workspaces-indicator-height;
+        border-radius: $bar-buttons-workspaces-indicator-radius;
         transition: 300ms * 0.5;
         background-color: $bar-buttons-workspaces-available;
         color: $bar-buttons-workspaces-available;
@@ -11,15 +11,15 @@
         &.occupied {
             background-color: $bar-buttons-workspaces-occupied;
             color: $bar-buttons-workspaces-occupied;
-            min-width: 4em;
-            min-height: 4em;
+            min-width: $bar-buttons-workspaces-indicator-width;
+            min-height: $bar-buttons-workspaces-indicator-height;
         }
 
         &.active {
             background-color: $bar-buttons-workspaces-active;
             color: $bar-buttons-workspaces-active;
-            min-width: 12em;
-            min-height: 4em;
+            min-width: $bar-buttons-workspaces-indicator-active_width;
+            min-height: $bar-buttons-workspaces-indicator-height;
         }
 
         &.workspace-icon {

--- a/src/scss/style/bar/workspace.scss
+++ b/src/scss/style/bar/workspace.scss
@@ -3,7 +3,7 @@
         font-size: 0.2em;
         min-width: 4em;
         min-height: 4em;
-        border-radius: 1.9rem * 0.6;
+        border-radius: $bar-buttons-workspaces-radius;
         transition: 300ms * 0.5;
         background-color: $bar-buttons-workspaces-available;
         color: $bar-buttons-workspaces-available;


### PR DESCRIPTION
This adds options for changing the shape of the bar's workspaces buttons.

Example:
![workspaces indicator example](https://raw.githubusercontent.com/okt/dotfiles/refs/heads/main/img/workspace_indicators.png)
```json
{
  "theme.bar.buttons.workspaces.indicator.radius": "1px",
  "theme.bar.buttons.workspaces.indicator.height": "2em",
  "theme.bar.buttons.workspaces.indicator.width": "8em",
  "theme.bar.buttons.workspaces.indicator.active_width": "18em"
}
```

I started with adding the radius so the shape could be tuned into a square shape from the default full-round (`1.9rem * 0.6`). Later ended up creating options for the `width`, `height`, `active_width`, & `radius`. 

I am still very much learning the project's layout and **am open to feedback on the organization of these kinds of options**, or verbiage in the title/subtitle text.

I'm also not sure if this is welcome as it **may be quite specific to my personal rice**. 