### PR TITLE
fix: add dependencies for bluetooth script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,9 +52,12 @@
           pkgs.gpu-screen-recorder
           pkgs.brightnessctl
           pkgs.gnome-bluetooth
-          pkgs.python3
+          (pkgs.python3.withPackages (python-pkgs: with python-pkgs; [
+            gpustat
+            dbus-python
+            pygobject3
+          ]))
           pkgs.matugen
-          pkgs.python312Packages.gpustat
           pkgs.hyprpicker
           pkgs.hyprsunset
           pkgs.hypridle


### PR DESCRIPTION
Fix the error below @orangci 
```
hyprpanel migrateConfig

(gjs:18259): hyprpanel-CRITICAL **: 18:03:09.689: Gio.IOErrorEnum: Traceback (most recent call last):
  File "/nix/store/j3cd4kx9jbiz0z6ysf45qxb6bs229m48-hyprpanel/share/scripts/bluetooth.py", line 3, in <module>
    import dbus
ModuleNotFoundError: No module named 'dbus'
execAsync/</<@file:///nix/store/j3cd4kx9jbiz0z6ysf45qxb6bs229m48-hyprpanel/bin/.hyprpanel-wrapped:76:33
_init/GLib.MainLoop.prototype.runAsync/</<@resource:///org/gnome/gjs/modules/core/overrides/GLib.js:263:34
```