### PR TITLE
Remove timeout from Hyprpanel notifications.

### DIFF
--- a/src/components/menus/network/wifi/APStaging/PasswordInput.tsx
+++ b/src/components/menus/network/wifi/APStaging/PasswordInput.tsx
@@ -29,7 +29,6 @@ export const PasswordInput = ({ connecting, staging }: PasswordInputProps): JSX.
                                 Notify({
                                     summary: 'Network',
                                     body: err.message,
-                                    timeout: 5000,
                                 });
                             })
                             .then(() => {

--- a/src/components/menus/network/wifi/WirelessAPs/helpers.ts
+++ b/src/components/menus/network/wifi/WirelessAPs/helpers.ts
@@ -239,7 +239,6 @@ export const connectToAP = (accessPoint: AstalNetwork.AccessPoint, event: Astal.
                 Notify({
                     summary: 'Network',
                     body: err.message,
-                    timeout: 5000,
                 });
             }
         });

--- a/src/components/settings/shared/FileChooser.ts
+++ b/src/components/settings/shared/FileChooser.ts
@@ -200,7 +200,6 @@ export const saveFileDialog = (filePath: string, themeOnly: boolean): void => {
                 summary: 'File Saved Successfully',
                 body: `At ${finalFilePath}.`,
                 iconName: icons.ui.info,
-                timeout: 5000,
             });
         } catch (e) {
             if (e instanceof Error) {
@@ -244,7 +243,6 @@ export const importFiles = (themeOnly: boolean = false): void => {
                 summary: 'Failed to import',
                 body: 'No file selected.',
                 iconName: icons.ui.warning,
-                timeout: 5000,
             });
             return;
         }
@@ -260,7 +258,6 @@ export const importFiles = (themeOnly: boolean = false): void => {
             summary: `Importing ${themeOnly ? 'Theme' : 'Config'}`,
             body: `Importing: ${filePath}`,
             iconName: icons.ui.info,
-            timeout: 7000,
         });
 
         const tmpConfigFile = Gio.File.new_for_path(`${TMP}/config.json`);

--- a/src/lib/behaviors/batteryWarning.ts
+++ b/src/lib/behaviors/batteryWarning.ts
@@ -44,7 +44,6 @@ export function warnOnLowBattery(): void {
                 body: lowBatteryNotificationText.get().replace('$POWER_LEVEL', batteryPercentage.toString()),
                 iconName: icons.ui.warning,
                 urgency: 'critical',
-                timeout: 7000,
             });
         }
     });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -198,7 +198,6 @@ export function dependencies(...bins: string[]): boolean {
             summary: 'Dependencies not found!',
             body: `The following dependencies are missing: ${missing.join(', ')}`,
             iconName: icons.ui.warning,
-            timeout: 7000,
         });
     }
 

--- a/src/scss/optionsTrackers.ts
+++ b/src/scss/optionsTrackers.ts
@@ -13,7 +13,6 @@ const ensureMatugenWallpaper = (): void => {
             summary: 'Matugen Failed',
             body: "Please select a wallpaper in 'Theming > General' first.",
             iconName: icons.ui.warning,
-            timeout: 7000,
         });
         matugen.set(false);
     }

--- a/src/services/matugen/index.ts
+++ b/src/services/matugen/index.ts
@@ -24,7 +24,6 @@ export async function generateMatugenColors(): Promise<MatugenColors | undefined
                 summary: 'Matugen Failed',
                 body: "Please select a wallpaper in 'Theming > General' first.",
                 iconName: icons.ui.warning,
-                timeout: 7000,
             });
             return;
         }


### PR DESCRIPTION
The popup handles the times anyways, these are not needed and cause notifications to disappear from the panel.

closes #596 