### PR TITLE
fix: missing class for bluetooth discover button

### DIFF
--- a/src/components/menus/bluetooth/header/Controls/DiscoverButton.tsx
+++ b/src/components/menus/bluetooth/header/Controls/DiscoverButton.tsx
@@ -6,7 +6,7 @@ import { isDiscovering } from './helper';
 
 export const DiscoverButton = (): JSX.Element => (
     <button
-        className="menu-icon-button search"
+        className="menu-icon-button search bluetooth"
         valign={Gtk.Align.CENTER}
         onClick={(_, self) => {
             if (!isPrimaryClick(self)) {


### PR DESCRIPTION
The discover button is not styled correctly, I'm guessing this is because the bluetooth class is missing, I did not test though.

![image](https://github.com/user-attachments/assets/9f1bd7c4-3c3c-44b5-a7a9-32b59b4df77a)

Based off [this styling](https://github.com/Jas-SinghFSU/HyprPanel/blob/master/src/components/menus/bluetooth/header/Controls/ToggleSwitch.tsx#L13) that is working and [this one](https://github.com/Jas-SinghFSU/HyprPanel/blob/master/src/components/menus/network/wifi/Controls/RefreshButton.tsx#L10) from the network menu.

```html
className="menu-icon-button search network"
```