### PR TITLE
nix: fixed bar.volume.scroll*-commands

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -273,8 +273,8 @@ in
       bar.volume.label = mkBoolOption true;
       bar.volume.middleClick = mkStrOption "";
       bar.volume.rightClick = mkStrOption "";
-      bar.volume.scrollDown = mkStrOption "${package}/bin/hyprpanel vol -5";
-      bar.volume.scrollUp = mkStrOption "${package}/bin/hyprpanel vol +5";
+      bar.volume.scrollDown = mkStrOption "${package}/bin/hyprpanel 'vol -5'";
+      bar.volume.scrollUp = mkStrOption "${package}/bin/hyprpanel 'vol +5'";
       bar.windowtitle.class_name = mkBoolOption true;
       bar.windowtitle.custom_title = mkBoolOption true;
       bar.windowtitle.icon = mkBoolOption true;


### PR DESCRIPTION
`-5` was incorrectly interpreted as an argument