### PR TITLE
Hyprland clients are now fetched from a binding instead of get_clients().

### DIFF
--- a/src/components/bar/modules/workspaces/helpers/utils.ts
+++ b/src/components/bar/modules/workspaces/helpers/utils.ts
@@ -194,25 +194,25 @@ export const renderClassnames = (
     monitor: number,
     i: number,
 ): string => {
+    const isWorkspaceActive = hyprlandService.focusedWorkspace?.id === i || isWorkspaceActiveOnMonitor(monitor, i);
+    const isActive = isWorkspaceActive ? 'active' : '';
+
     if (showIcons) {
-        return 'workspace-icon txt-icon bar';
+        return `workspace-icon txt-icon bar ${isActive}`;
     }
 
     if (showNumbered || showWsIcons) {
-        const numActiveInd =
-            hyprlandService.focusedWorkspace?.id === i || isWorkspaceActiveOnMonitor(monitor, i)
-                ? numberedActiveIndicator
-                : '';
+        const numActiveInd = isWorkspaceActive ? numberedActiveIndicator : '';
 
         const wsIconClass = showWsIcons ? 'txt-icon' : '';
         const smartHighlightClass = smartHighlight ? 'smart-highlight' : '';
 
-        const className = `workspace-number can_${numberedActiveIndicator} ${numActiveInd} ${wsIconClass} ${smartHighlightClass}`;
+        const className = `workspace-number can_${numberedActiveIndicator} ${numActiveInd} ${wsIconClass} ${smartHighlightClass} ${isActive}`;
 
         return className.trim();
     }
 
-    return 'default';
+    return `default ${isActive}`;
 };
 
 /**

--- a/src/components/bar/modules/workspaces/workspaces.tsx
+++ b/src/components/bar/modules/workspaces/workspaces.tsx
@@ -149,7 +149,8 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                                 monitor,
                             )}
                             setup={(self) => {
-                                self.toggleClassName('occupied', clients.length > 0);
+                                const currentWsClients = clients.filter((client) => client.workspace.id === wsId);
+                                self.toggleClassName('occupied', currentWsClients.length > 0);
                             }}
                         />
                     </button>

--- a/src/components/bar/modules/workspaces/workspaces.tsx
+++ b/src/components/bar/modules/workspaces/workspaces.tsx
@@ -55,8 +55,9 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             bind(applicationIconFallback),
             bind(matugen),
             bind(smartHighlight),
-
+            bind(hyprlandService, 'clients'),
             bind(hyprlandService, 'monitors'),
+
             bind(ignored),
             bind(showAllActive),
             bind(hyprlandService, 'focusedWorkspace'),
@@ -84,6 +85,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             applicationIconFallback: string,
             matugenEnabled: boolean,
             smartHighlightEnabled: boolean,
+            clients: AstalHyprland.Client[],
             monitorList: AstalHyprland.Monitor[],
         ) => {
             const activeWorkspace = hyprlandService.focusedWorkspace?.id || -99999;
@@ -150,10 +152,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                             )}
                             setup={(self) => {
                                 self.toggleClassName('active', activeWorkspace === wsId);
-                                self.toggleClassName(
-                                    'occupied',
-                                    (hyprlandService.get_workspace(wsId)?.get_clients()?.length || 0) > 0,
-                                );
+                                self.toggleClassName('occupied', clients.length > 0);
                             }}
                         />
                     </button>

--- a/src/components/bar/modules/workspaces/workspaces.tsx
+++ b/src/components/bar/modules/workspaces/workspaces.tsx
@@ -88,8 +88,6 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             clients: AstalHyprland.Client[],
             monitorList: AstalHyprland.Monitor[],
         ) => {
-            const activeWorkspace = hyprlandService.focusedWorkspace?.id || -99999;
-
             const workspacesToRender = getWorkspacesToRender(
                 totalWorkspaces,
                 workspaceList,
@@ -151,7 +149,6 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                                 monitor,
                             )}
                             setup={(self) => {
-                                self.toggleClassName('active', activeWorkspace === wsId);
                                 self.toggleClassName('occupied', clients.length > 0);
                             }}
                         />


### PR DESCRIPTION
Additionally, active workspaces now show appropriately on all workspace styles.