### PR TITLE
nix: fix #666

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,14 +3,16 @@
     "ags": {
       "inputs": {
         "astal": "astal",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1735430786,
-        "narHash": "sha256-y3GiH8wFEQh4HNBfW1jlSORxwCzsKB8URufYAGo8zQE=",
+        "lastModified": 1735485506,
+        "narHash": "sha256-7CWr3Q83KnGiLUn0oaboafLMOXQ0X9/fjFRVY1xopbM=",
         "owner": "aylur",
         "repo": "ags",
-        "rev": "99f1c3f5b51ac86a42319ef25ef2cea413379505",
+        "rev": "251d39413543264361898b02035775aa3e46fe52",
         "type": "github"
       },
       "original": {
@@ -40,57 +42,7 @@
         "type": "github"
       }
     },
-    "astal_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1735382966,
-        "narHash": "sha256-xBh40ENNkS0GdgKT+zFT9lBHiAwrM1iQEjkDDp208lQ=",
-        "owner": "aylur",
-        "repo": "astal",
-        "rev": "b89b08ef482a30726d9e716f593b449ce640099f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aylur",
-        "repo": "astal",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1735291276,
         "narHash": "sha256-NYVcA06+blsLG6wpAbSPTCyLvxD/92Hy4vlY9WxFI1M=",
@@ -109,8 +61,7 @@
     "root": {
       "inputs": {
         "ags": "ags",
-        "astal": "astal_2",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,19 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    ags.url = "github:aylur/ags";
-    astal.url = "github:aylur/astal";
+
+    ags = {
+      url = "github:aylur/ags";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, ags, astal }: let
-    systems = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-      "aarch64-linux"
-    ];
+  outputs = {
+    self,
+    nixpkgs,
+    ags,
+  }: let
+    systems = ["x86_64-linux" "aarch64-linux"];
     forEachSystem = nixpkgs.lib.genAttrs systems;
   in {
     packages = forEachSystem (system: let
@@ -23,50 +25,52 @@
         name = "hyprpanel"; # name of executable
         entry = "app.ts";
 
-        # additional libraries and executables to add to gjs' runtime
-        extraPackages = [
-          ags.packages.${system}.agsFull
-          astal.packages.${system}.tray
-          astal.packages.${system}.hyprland
-          astal.packages.${system}.io
-          astal.packages.${system}.apps
-          astal.packages.${system}.battery
-          astal.packages.${system}.bluetooth
-          astal.packages.${system}.mpris
-          astal.packages.${system}.network
-          astal.packages.${system}.notifd
-          astal.packages.${system}.powerprofiles
-          astal.packages.${system}.wireplumber
-          pkgs.fish
-          pkgs.typescript
-          pkgs.libnotify
-          pkgs.dart-sass
-          pkgs.fd
-          pkgs.btop
-          pkgs.bluez
-          pkgs.libgtop
-          pkgs.gobject-introspection
-          pkgs.glib
-          pkgs.bluez-tools
-          pkgs.grimblast
-          pkgs.brightnessctl
-          pkgs.gnome-bluetooth
-          (pkgs.python3.withPackages (python-pkgs: with python-pkgs; [
-            gpustat
-            dbus-python
-            pygobject3
-          ]))
-          pkgs.matugen
-          pkgs.hyprpicker
-          pkgs.hyprsunset
-          pkgs.hypridle
-          pkgs.wireplumber
-          pkgs.networkmanager
-          pkgs.upower
-          pkgs.gvfs
-          pkgs.swww
-          pkgs.pywal
-        ] ++ (nixpkgs.lib.optionals (system == "x86_64-linux") [pkgs.gpu-screen-recorder]);
+        extraPackages =
+          (with ags.packages.${system}; [
+            tray
+            hyprland
+            apps
+            battery
+            bluetooth
+            mpris
+            network
+            notifd
+            powerprofiles
+            wireplumber
+          ])
+          ++ (with pkgs; [
+            fish
+            typescript
+            libnotify
+            dart-sass
+            fd
+            btop
+            bluez
+            libgtop
+            gobject-introspection
+            glib
+            bluez-tools
+            grimblast
+            brightnessctl
+            gnome-bluetooth
+            (python3.withPackages (ps:
+              with ps; [
+                gpustat
+                dbus-python
+                pygobject3
+              ]))
+            matugen
+            hyprpicker
+            hyprsunset
+            hypridle
+            wireplumber
+            networkmanager
+            upower
+            gvfs
+            swww
+            pywal
+          ])
+          ++ (nixpkgs.lib.optionals (system == "x86_64-linux") [pkgs.gpu-screen-recorder]);
       };
     });
 
@@ -76,7 +80,7 @@
         if [ "$#" -eq 0 ]; then
             exec ${self.packages.${final.stdenv.system}.default}/bin/hyprpanel
         else
-            exec ${astal.packages.${final.stdenv.system}.io}/bin/astal -i hyprpanel "$@"
+            exec ${ags.packages.${final.stdenv.system}.io}/bin/astal -i hyprpanel "$@"
         fi
       '';
     };


### PR DESCRIPTION
This PR also
- removes darwin from the list of supported systems, since its not supported https://github.com/Aylur/astal/pull/201
- removed astal from builtinputs, because the packages used are also exposed by the ags flake
- formatted buildInputs to use the `with` keyword
- formatted with alejandra