### PR TITLE
chore(style): remove min-width on volume button

### DIFF
--- a/src/scss/style/bar/audio.scss
+++ b/src/scss/style/bar/audio.scss
@@ -5,7 +5,6 @@
 
 .bar-button-label.volume {
     color: if($bar-buttons-monochrome, $bar-buttons-text, $bar-buttons-volume-text);
-    min-width: 2.2em;
     margin-left: $bar-buttons-volume-spacing;
 }
 


### PR DESCRIPTION
It's awkward to have a min-width on volume percentage and not on battery, it looks more natural when fitting the content so I removed the min-width