### PR TITLE
Updated popup menu layouts and fixed workspace behavior.

### DIFF
--- a/src/components/bar/modules/workspaces/helpers/index.ts
+++ b/src/components/bar/modules/workspaces/helpers/index.ts
@@ -94,13 +94,15 @@ function isWorkspaceValidForMonitor(
     });
 
     const currentMonitorName = monitorNameMap[monitorId];
-    const currentMonitorWorkspaceRules = workspaceMonitorRules[currentMonitorName];
+    const currentMonitorWorkspaceRules = workspaceMonitorRules[currentMonitorName] ?? [];
+    const activeWorkspaceIds = new Set(allWorkspaceInstances.map((ws) => ws.id));
+    const filteredWorkspaceRules = currentMonitorWorkspaceRules.filter((ws) => !activeWorkspaceIds.has(ws));
 
-    if (currentMonitorWorkspaceRules === undefined) {
+    if (filteredWorkspaceRules === undefined) {
         return false;
     }
 
-    return currentMonitorWorkspaceRules.includes(workspaceId);
+    return filteredWorkspaceRules.includes(workspaceId);
 }
 
 /**
@@ -319,6 +321,12 @@ export function getWorkspacesToRender(
     );
 
     const activeWorkspacesForCurrentMonitor = activeWorkspaceIds.filter((workspaceId) => {
+        const metadataForWorkspace = allWorkspaceInstances.find((workspaceObj) => workspaceObj.id === workspaceId);
+
+        if (metadataForWorkspace) {
+            return metadataForWorkspace?.monitor?.id === monitorId;
+        }
+
         if (
             currentMonitorInstance &&
             Object.hasOwnProperty.call(workspaceMonitorRules, currentMonitorInstance.name) &&
@@ -326,8 +334,6 @@ export function getWorkspacesToRender(
         ) {
             return workspaceMonitorRules[currentMonitorInstance.name].includes(workspaceId);
         }
-        const metadataForWorkspace = allWorkspaceInstances.find((workspaceObj) => workspaceObj.id === workspaceId);
-        return metadataForWorkspace?.monitor?.id === monitorId;
     });
 
     if (isMonitorSpecific) {

--- a/src/components/menus/power/verification.tsx
+++ b/src/components/menus/power/verification.tsx
@@ -4,8 +4,8 @@ import { App, Gtk } from 'astal/gtk3';
 import { bind } from 'astal';
 
 export default (): JSX.Element => (
-    <PopupWindow name="verification" transition="crossfade">
-        <box className="verification">
+    <PopupWindow name="verification" transition="crossfade" layout={'center'}>
+        <box className="verification" expand={false}>
             <box className="verification-content" expand vertical>
                 <box className="text-box" vertical>
                     <label className="title" label={bind(powermenu, 'title').as((t) => t.toUpperCase())} />

--- a/src/components/menus/shared/popup/index.tsx
+++ b/src/components/menus/shared/popup/index.tsx
@@ -57,8 +57,7 @@ const Layout: LayoutFunction = (name: string, child: GtkWidget, transition: Gtk.
     'top-right': () => (
         <box>
             <Padding name={name} />
-            <box hexpand vertical>
-                <Padding name={name} opts={{ vexpand: false, className: 'event-top-padding' }} />
+            <box hexpand={false} vertical>
                 <PopupRevealer name={name} child={child} transition={transition} />
                 <Padding name={name} />
             </box>
@@ -77,9 +76,7 @@ const Layout: LayoutFunction = (name: string, child: GtkWidget, transition: Gtk.
     ),
     'top-left': () => (
         <box>
-            <Padding name={name} />
             <box hexpand={false} vertical>
-                <Padding name={name} opts={{ vexpand: false, className: 'event-top-padding' }} />
                 <PopupRevealer name={name} child={child} transition={transition} />
                 <Padding name={name} />
             </box>


### PR DESCRIPTION
This update will make the module rely on active workspace info first before relying on workspace rules if the workspace isn't active. This makes it so if there is desync or issues in hyprland where a workspace isn't showing up on the monitor that the rule is defined for, it not longer shows duplicates on both the intended monitor and the incorrectly set monitor (the one the workspace is inaccurately showing up on).