### PR TITLE
fix(window-title): correct Thorium title name

### DIFF
--- a/src/components/bar/modules/window_title/helpers/title.ts
+++ b/src/components/bar/modules/window_title/helpers/title.ts
@@ -36,7 +36,7 @@ export const getWindowMatch = (client: AstalHyprland.Client): Record<string, str
         ['opera', '', 'Opera'],
         ['vivaldi', '󰖟', 'Vivaldi'],
         ['waterfox', '󰖟', 'Waterfox'],
-        ['thorium', '󰖟', 'Waterfox'],
+        ['thorium', '󰖟', 'Thorium'],
         ['tor-browser', '', 'Tor Browser'],
         ['floorp', '󰈹', 'Floorp'],
 


### PR DESCRIPTION
Hey :wave: small PR fixing the window title if the detected browser is thorium, not sure why it's waterfox but I assume that was just a simple copy-paste mistak.