### PR TITLE
Update bluetooth label when a new device connects/disconnects

### DIFF
--- a/src/components/bar/modules/bluetooth/index.tsx
+++ b/src/components/bar/modules/bluetooth/index.tsx
@@ -38,7 +38,13 @@ const Bluetooth = (): BarBoxChild => {
     );
 
     const componentBinding = Variable.derive(
-        [bind(options.bar.bluetooth.label), bind(bluetoothService, 'isPowered'), bind(bluetoothService, 'devices')],
+        [
+            bind(options.bar.bluetooth.label),
+            bind(bluetoothService, 'isPowered'),
+            bind(bluetoothService, 'devices'),
+
+            bind(bluetoothService, 'isConnected'),
+        ],
         (showLabel: boolean, isPowered: boolean, devices: AstalBluetooth.Device[]): JSX.Element => {
             if (showLabel) {
                 return (


### PR DESCRIPTION
Just adds the missing bind to `isConnected` to update the label when a new device is connected