### PR TITLE
feat(hypridle): fixes #643 by making commands customizable

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -203,6 +203,9 @@ in
       bar.customModules.hypridle.rightClick = mkStrOption "";
       bar.customModules.hypridle.scrollDown = mkStrOption "";
       bar.customModules.hypridle.scrollUp = mkStrOption "";
+      bar.customModules.hypridle.startCommand = "systemctl --user start hypridle.service";
+      bar.customModules.hypridle.stopCommand = "systemctl --user stop hypridle.service";
+      bar.customModules.hypridle.isActiveCommand = "systemctl --user status hypridle.service | grep -q 'Active: active (running)' && echo 'yes' || echo 'no'";
       bar.customModules.hyprsunset.label = mkBoolOption true;
       bar.customModules.hyprsunset.middleClick = mkStrOption "";
       bar.customModules.hyprsunset.offIcon = mkStrOption "󰛨";

--- a/src/components/bar/modules/hypridle/helpers/index.ts
+++ b/src/components/bar/modules/hypridle/helpers/index.ts
@@ -1,12 +1,15 @@
+import options from 'src/options';
 import { execAsync, Variable } from 'astal';
+
+const { startCommand, stopCommand, isActiveCommand } = options.bar.customModules.hypridle;
 
 /**
  * Checks if the hypridle process is active.
  *
- * This command checks if the hypridle process is currently running by using the `pgrep` command.
+ * This command checks if the hypridle process is currently running by using the configured `isActiveCommand`.
  * It returns 'yes' if the process is found and 'no' otherwise.
  */
-export const isActiveCommand = `bash -c "pgrep -x 'hypridle' &>/dev/null && echo 'yes' || echo 'no'"`;
+export const isActiveCmd = `bash -c "${isActiveCommand.get()}"`;
 
 /**
  * A variable to track the active state of the hypridle process.
@@ -21,8 +24,8 @@ export const isActive = Variable(false);
  * @param isActive A Variable<boolean> that tracks the active state of the hypridle process.
  */
 const updateIsActive = (isActive: Variable<boolean>): void => {
-    execAsync(isActiveCommand).then((res) => {
-        isActive.set(res === 'yes');
+    execAsync(isActiveCmd).then((res) => {
+        isActive.set(res.trim() === 'yes');
     });
 };
 
@@ -35,9 +38,9 @@ const updateIsActive = (isActive: Variable<boolean>): void => {
  * @param isActive A Variable<boolean> that tracks the active state of the hypridle process.
  */
 export const toggleIdle = (isActive: Variable<boolean>): void => {
-    execAsync(isActiveCommand).then((res) => {
+    execAsync(isActiveCmd).then((res) => {
         const toggleIdleCommand =
-            res === 'no' ? `bash -c "nohup hypridle > /dev/null 2>&1 &"` : `bash -c "pkill hypridle"`;
+            res.trim() === 'no' ? `bash -c "${startCommand.get()}"` : `bash -c "${stopCommand.get()}"`;
 
         execAsync(toggleIdleCommand).then(() => updateIsActive(isActive));
     });
@@ -49,7 +52,7 @@ export const toggleIdle = (isActive: Variable<boolean>): void => {
  * This function checks if the hypridle process is currently running and updates the `isActive` variable accordingly.
  */
 export const checkIdleStatus = (): undefined => {
-    execAsync(isActiveCommand).then((res) => {
-        isActive.set(res === 'yes');
+    execAsync(isActiveCmd).then((res) => {
+        isActive.set(res.trim() === 'yes');
     });
 };

--- a/src/components/bar/settings/config.tsx
+++ b/src/components/bar/settings/config.tsx
@@ -353,6 +353,21 @@ export const CustomModuleSettings = (): JSX.Element => {
                 <Option opt={options.bar.customModules.hypridle.middleClick} title="Middle Click" type="string" />
                 <Option opt={options.bar.customModules.hypridle.scrollUp} title="Scroll Up" type="string" />
                 <Option opt={options.bar.customModules.hypridle.scrollDown} title="Scroll Down" type="string" />
+                <Option
+                    opt={options.bar.customModules.hypridle.startCommand}
+                    title="Start Hypridle Command"
+                    type="string"
+                />
+                <Option
+                    opt={options.bar.customModules.hypridle.stopCommand}
+                    title="Stop Hypridle Command"
+                    type="string"
+                />
+                <Option
+                    opt={options.bar.customModules.hypridle.isActiveCommand}
+                    title="Hypridle Status Command"
+                    type="string"
+                />
 
                 {/* Cava Section */}
                 <Header title="Cava" />

--- a/src/options.ts
+++ b/src/options.ts
@@ -1181,6 +1181,9 @@ const options = mkOptions(CONFIG, {
                 middleClick: opt(''),
                 scrollUp: opt(''),
                 scrollDown: opt(''),
+                isActiveCommand: opt("pgrep -x 'hypridle' &>/dev/null && echo 'yes' || echo 'no'"),
+                startCommand: opt('nohup hypridle > /dev/null 2>&1 &'),
+                stopCommand: opt('pkill hypridle'),
             },
             cava: {
                 showIcon: opt(true),


### PR DESCRIPTION
Hypridle can be started both by running the binary at startup `exec-once = hypridle` or a user service with systemd `systemctl --user enable --now hypridle.service` as noted on the documentation [usage section](https://github.com/hyprwm/hypridle?tab=readme-ov-file#usage). Hyprpanel custom module for Hypridle fails when it is started with system ad reported on https://github.com/Jas-SinghFSU/HyprPanel/issues/643, which makes sense when looking at the commands used to start, stop and check status of Hypridle. See
https://github.com/Jas-SinghFSU/HyprPanel/blob/88609f7e4c244326face34cb992a79053f2c7810/src/components/bar/modules/hypridle/helpers/index.ts#L9 and https://github.com/Jas-SinghFSU/HyprPanel/blob/88609f7e4c244326face34cb992a79053f2c7810/src/components/bar/modules/hypridle/helpers/index.ts#L40
Running `pkill hypridle` when it has been started with systemd will only temporarily stop Hypridle and systemd is gonna restart it in a few seconds, resulting in the reported behavior at the above mentioned issue.

This pull request adds the possibility to customize said commands but maintains the default values they had for the sake of backwards compatibility. Except for NixOS where it does set commands using systemd since it seems to be the most common and recommended way.

I have tested it still works with the default values as it did until now when not using systemd. 

For NixOS users that start Hypridle with Hyrpland's `exec-once` and  want to keep the old behavior, set the options to the following:



```nix
bar.customModules.hypridle.startCommand = mkStrOption "nohup hypridle > /dev/null 2>&1 &";
bar.customModules.hypridle.stopCommand = mkStrOption "pkill hypridle";
bar.customModules.hypridle.isActiveCommand = mkStrOption "pgrep -x 'hypridle' &>/dev/null && echo 'yes' || echo 'no'";
```