### PR TITLE
fix: change workspace spacing option to float

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -351,7 +351,7 @@ in
       bar.workspaces.showWsIcons = mkBoolOption false;
       bar.workspaces.show_icons = mkBoolOption false;
       bar.workspaces.show_numbered = mkBoolOption false;
-      bar.workspaces.spacing = mkIntOption 1;
+      bar.workspaces.spacing = mkFloatOption 1.0;
       bar.workspaces.workspaceMask = mkBoolOption false;
       bar.workspaces.workspaces = mkIntOption 5;
       dummy = mkBoolOption true;


### PR DESCRIPTION
Hi, I made a small change in the nix module.

`bar.workspaces.spacing` should take a float option, but the nix module used `mkIntOption` for this; I changed it to `mkFloatOption`. Tested on my machine.

Please let me know what you think!