### PR TITLE
Workaround unreliable GDK geometry scaling for matching monitors

### DIFF
--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -144,6 +144,17 @@ export const gdkMonitorIdToHyprlandId = (monitor: number, usedHyprlandMonitors: 
         //  2) The geometry is scaled by the scaleFactor (the fractional scale rounded up)
         const keyMatch = gdkMonitor.key === scaleFactorKey || gdkMonitor.key === scaleKey;
 
+        // Adding debug logging
+        console.log('Attempting 1st gdk key match');
+        console.log(`GDK key: ${gdkMonitor.key}`);
+        console.log(`HypMon.width: ${hypMon.width}`);
+        console.log(`HypMon.height: ${hypMon.height}`);
+        console.log(`HypMon.scale: ${hypMon.scale}`);
+        console.log(`scaleFactor: ${gdkScaleFactor}`);
+        console.log(`scaleFactorKey: ${scaleFactorKey}`);
+        console.log(`scaleKey: ${scaleKey}`);
+        console.log(`match?: ${keyMatch}`);
+
         return keyMatch && !usedHyprlandMonitors.has(hypMon.id) && hypMon.id === monitor;
     });
 
@@ -176,6 +187,17 @@ export const gdkMonitorIdToHyprlandId = (monitor: number, usedHyprlandMonitors: 
         //  1) The geometry is scaled by the correct fractional scale
         //  2) The geometry is scaled by the scaleFactor (the fractional scale rounded up)
         const keyMatch = gdkMonitor.key === scaleFactorKey || gdkMonitor.key === scaleKey;
+
+        // Adding debug logging
+        console.log('Attempting 2nd gdk key match');
+        console.log(`GDK key: ${gdkMonitor.key}`);
+        console.log(`HypMon.width: ${hypMon.width}`);
+        console.log(`HypMon.height: ${hypMon.height}`);
+        console.log(`HypMon.scale: ${hypMon.scale}`);
+        console.log(`scaleFactor: ${gdkScaleFactor}`);
+        console.log(`scaleFactorKey: ${scaleFactorKey}`);
+        console.log(`scaleKey: ${scaleKey}`);
+        console.log(`match?: ${keyMatch}`);
 
         return keyMatch && !usedHyprlandMonitors.has(hypMon.id);
     });

--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -72,8 +72,7 @@ export function getGdkMonitors(): GdkMonitors {
 }
 
 export function matchMonitorKey(hypMon: Set, gdkMonitor: Set): boolean {
-    const transform = hypMon?.transform !== undefined ? 0 : hypMon.transform;
-    const isRotated90 = transform % 2 !== 0;
+    const isRotated90 = hypMon.transform % 2 !== 0;
 
     // Needed for the key regardless of scaling below because GDK3 only has the scale factor for the key
     const gdkScaleFactor = Math.ceil(hypMon.scale);

--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -5,10 +5,10 @@ import { BarLayout, BarLayouts } from 'src/lib/types/options';
 const hyprlandService = AstalHyprland.get_default();
 
 type GdkMonitor = {
-  key: string;
-  model: string;
-  used: boolean;
-}
+    key: string;
+    model: string;
+    used: boolean;
+};
 
 type GdkMonitors = {
     [key: string]: GdkMonitor;

--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -4,12 +4,14 @@ import { BarLayout, BarLayouts } from 'src/lib/types/options';
 
 const hyprlandService = AstalHyprland.get_default();
 
+type GdkMonitor = {
+  key: string;
+  model: string;
+  used: boolean;
+}
+
 type GdkMonitors = {
-    [key: string]: {
-        key: string;
-        model: string;
-        used: boolean;
-    };
+    [key: string]: GdkMonitor;
 };
 
 export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLayout => {
@@ -71,7 +73,7 @@ export function getGdkMonitors(): GdkMonitors {
     return gdkMonitors;
 }
 
-export function matchMonitorKey(hypMon: Set, gdkMonitor: Set): boolean {
+export function matchMonitorKey(hypMon: AstalHyprland.Monitor, gdkMonitor: GdkMonitor): boolean {
     const isRotated90 = hypMon.transform % 2 !== 0;
 
     // Needed for the key regardless of scaling below because GDK3 only has the scale factor for the key

--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -101,7 +101,7 @@ export function matchMonitorKey(hypMon: AstalHyprland.Monitor, gdkMonitor: GdkMo
 
     // Monitor matching debug logging, use if your workspaces are appearing on the wrong screen
     // To use, kill any running HyprPanel instances and then start a terminal, then run:
-    //    G_MESSAGES_DEBUG='GNOME Shell' hyprpanel
+    //    G_MESSAGES_DEBUG=all hyprpanel | grep "hyprpanel-DEBUG"
     // Create an issue in HyprPanel github and post these logs
     console.debug('Attempting gdk key match');
     console.debug(`GDK key: ${gdkMonitor.key}`);

--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -123,18 +123,20 @@ export const gdkMonitorIdToHyprlandId = (monitor: number, usedHyprlandMonitors: 
     const directMatch = hyprlandService.get_monitors().find((hypMon) => {
         const isVertical = hypMon?.transform !== undefined ? hypMon.transform % 2 !== 0 : false;
 
+        // Needed for the key regardless of scaling below because GDK3 only has the scale factor for the key
         const gdkScaleFactor = Math.ceil(hypMon.scale);
 
-        const width = isVertical ? hypMon.height : hypMon.width;
-        const height = isVertical ? hypMon.width : hypMon.height;
-
-        const scaleFactorWidth = Math.trunc(width / gdkScaleFactor);
-        const scaleFactorHeight = Math.trunc(height / gdkScaleFactor);
+        // When gdk is scaled with the scale factor, the hyprland width/height will be the same as the base monitor resolution
+        // It will be the same REGARDLESS of transformation (e.g. 90 degrees will NOT swap the GDK width/height) 
+        const scaleFactorWidth = Math.trunc(hypMon.width / gdkScaleFactor);
+        const scaleFactorHeight = Math.trunc(hypMon.height / gdkScaleFactor);
         const scaleFactorKey = `${hypMon.model}_${scaleFactorWidth}x${scaleFactorHeight}_${gdkScaleFactor}`;
 
-        const scaleWidth = Math.trunc(width / hypMon.scale);
-        const scaleHeight = Math.trunc(height / hypMon.scale);
-        const scaleKey = `${hypMon.model}_${scaleWidth}x${scaleHeight}_${gdkScaleFactor}`;
+        // When gdk geometry is scaled with the fractional scale, the hyprland width/height are already scaled similarly
+        // So there's no need to scale it again. However a 90 degree transformation WILL flip width/height
+        const transWidth = isVertical ? hypMon.height : hypMon.width;
+        const transHeight = isVertical ? hypMon.width : hypMon.height;
+        const scaleKey = `${hypMon.model}_${transWidth}x${transHeight}_${gdkScaleFactor}`;
 
         // In GDK3 the GdkMonitor geometry can change depending on how the compositor handles scaling surface framebuffers
         // We try to match against two different possibilities:
@@ -154,18 +156,20 @@ export const gdkMonitorIdToHyprlandId = (monitor: number, usedHyprlandMonitors: 
     const hyprlandMonitor = hyprlandService.get_monitors().find((hypMon) => {
         const isVertical = hypMon?.transform !== undefined ? hypMon.transform % 2 !== 0 : false;
 
+        // Needed for the key regardless of scaling below because GDK3 only has the scale factor for the key
         const gdkScaleFactor = Math.ceil(hypMon.scale);
 
-        const width = isVertical ? hypMon.height : hypMon.width;
-        const height = isVertical ? hypMon.width : hypMon.height;
-
-        const scaleFactorWidth = Math.trunc(width / gdkScaleFactor);
-        const scaleFactorHeight = Math.trunc(height / gdkScaleFactor);
+        // When gdk is scaled with the scale factor, the hyprland width/height will be the same as the base monitor resolution
+        // It will be the same REGARDLESS of transformation (e.g. 90 degrees will NOT swap the GDK width/height) 
+        const scaleFactorWidth = Math.trunc(hypMon.width / gdkScaleFactor);
+        const scaleFactorHeight = Math.trunc(hypMon.height / gdkScaleFactor);
         const scaleFactorKey = `${hypMon.model}_${scaleFactorWidth}x${scaleFactorHeight}_${gdkScaleFactor}`;
 
-        const scaleWidth = Math.trunc(width / hypMon.scale);
-        const scaleHeight = Math.trunc(height / hypMon.scale);
-        const scaleKey = `${hypMon.model}_${scaleWidth}x${scaleHeight}_${gdkScaleFactor}`;
+        // When gdk geometry is scaled with the fractional scale, the hyprland width/height are already scaled similarly
+        // So there's no need to scale it again. However a 90 degree transformation WILL flip width/height
+        const transWidth = isVertical ? hypMon.height : hypMon.width;
+        const transHeight = isVertical ? hypMon.width : hypMon.height;
+        const scaleKey = `${hypMon.model}_${transWidth}x${transHeight}_${gdkScaleFactor}`;
 
         // In GDK3 the GdkMonitor geometry can change depending on how the compositor handles scaling surface framebuffers
         // We try to match against two different possibilities:

--- a/src/components/bar/utils/monitors.ts
+++ b/src/components/bar/utils/monitors.ts
@@ -78,13 +78,13 @@ export function matchMonitorKey(hypMon: Set, gdkMonitor: Set): boolean {
     const gdkScaleFactor = Math.ceil(hypMon.scale);
 
     // When gdk is scaled with the scale factor, the hyprland width/height will be the same as the base monitor resolution
-    // The GDK width/height will NOT flip regardless of transformation (e.g. 90 degrees will NOT swap the GDK width/height) 
+    // The GDK width/height will NOT flip regardless of transformation (e.g. 90 degrees will NOT swap the GDK width/height)
     const scaleFactorWidth = Math.trunc(hypMon.width / gdkScaleFactor);
     const scaleFactorHeight = Math.trunc(hypMon.height / gdkScaleFactor);
     const scaleFactorKey = `${hypMon.model}_${scaleFactorWidth}x${scaleFactorHeight}_${gdkScaleFactor}`;
 
     // When gdk geometry is scaled with the fractional scale, we need to scale the hyprland geometry to match it
-    // However a 90 degree transformation WILL flip the GDK width/height 
+    // However a 90 degree transformation WILL flip the GDK width/height
     const transWidth = isRotated90 ? hypMon.height : hypMon.width;
     const transHeight = isRotated90 ? hypMon.width : hypMon.height;
     const scaleWidth = Math.trunc(transWidth / hypMon.scale);
@@ -96,22 +96,25 @@ export function matchMonitorKey(hypMon: Set, gdkMonitor: Set): boolean {
     //  1) The geometry is scaled by the correct fractional scale
     //  2) The geometry is scaled by the scaleFactor (the fractional scale rounded up)
     const keyMatch = gdkMonitor.key === scaleFactorKey || gdkMonitor.key === scaleKey;
-    
-    // Adding debug logging
-    console.log('Attempting gdk key match');
-    console.log(`GDK key: ${gdkMonitor.key}`);
-    console.log(`HypMon.width: ${hypMon.width}`);
-    console.log(`HypMon.height: ${hypMon.height}`);
-    console.log(`HypMon.scale: ${hypMon.scale}`);
-    console.log(`HypMon.transform: ${hypMon.transform}`);
-    console.log(`isRotated90: ${isRotated90}`);
-    console.log(`scaleFactor: ${gdkScaleFactor}`);
-    console.log(`scaleFactorKey: ${scaleFactorKey}`);
-    console.log(`scaleKey: ${scaleKey}`);
-    console.log(`match?: ${keyMatch}`);
 
-    return keyMatch
-};
+    // Monitor matching debug logging, use if your workspaces are appearing on the wrong screen
+    // To use, kill any running HyprPanel instances and then start a terminal, then run:
+    //    G_MESSAGES_DEBUG='GNOME Shell' hyprpanel
+    // Create an issue in HyprPanel github and post these logs
+    console.debug('Attempting gdk key match');
+    console.debug(`GDK key: ${gdkMonitor.key}`);
+    console.debug(`HypMon.width: ${hypMon.width}`);
+    console.debug(`HypMon.height: ${hypMon.height}`);
+    console.debug(`HypMon.scale: ${hypMon.scale}`);
+    console.debug(`HypMon.transform: ${hypMon.transform}`);
+    console.debug(`isRotated90: ${isRotated90}`);
+    console.debug(`scaleFactor: ${gdkScaleFactor}`);
+    console.debug(`scaleFactorKey: ${scaleFactorKey}`);
+    console.debug(`scaleKey: ${scaleKey}`);
+    console.debug(`match?: ${keyMatch}`);
+
+    return keyMatch;
+}
 
 /**
  * NOTE: Some more funky stuff being done by GDK.
@@ -152,7 +155,6 @@ export function matchMonitorKey(hypMon: Set, gdkMonitor: Set): boolean {
  */
 
 export const gdkMonitorIdToHyprlandId = (monitor: number, usedHyprlandMonitors: Set<number>): number => {
-
     const gdkMonitors = getGdkMonitors();
 
     if (Object.keys(gdkMonitors).length === 0) {


### PR DESCRIPTION
Building on top of the testing and discussion in https://github.com/Jas-SinghFSU/HyprPanel/pull/713 

@Sawy7, sorry for the hijack! Happy for these changes to go into your PR instead, I just want to quickly test this. 

Should fix https://github.com/Jas-SinghFSU/HyprPanel/issues/636 but needs to be tested by the folks in https://github.com/Jas-SinghFSU/HyprPanel/pull/713 who had fractionally scaled GDK geometry.

This should be linted correctly, please let me know if the comments are incorrect or if you have any other changes you want to make.  