### PR TITLE
Fix undefined tooltip text

### DIFF
--- a/src/components/bar/shared/Module.tsx
+++ b/src/components/bar/shared/Module.tsx
@@ -10,7 +10,7 @@ export const Module = ({
     textIcon,
     useTextIcon = bind(Variable(false)),
     label,
-    tooltipText,
+    tooltipText = '',
     boxClass,
     isVis,
     props = {},


### PR DESCRIPTION
A new Astral update doesn't let the modules tool tip text be undefined, which leads to a nasty crash:

![image](https://github.com/user-attachments/assets/ada620b0-5f0d-416f-99a5-9ad4424deb65)

In my case it happened because the cava module doesn't have any tooltip, I dont know if it could happen in other places