### PR TITLE
Add Zen browser icon to window titles and media.

### DIFF
--- a/src/components/bar/modules/media/helpers/index.ts
+++ b/src/components/bar/modules/media/helpers/index.ts
@@ -30,7 +30,7 @@ const getIconForPlayer = (playerName: string): string => {
         ['Vivaldi', '󰖟'],
         ['Waterfox', '󰈹'],
         ['Thorium', '󰈹'],
-        ['Zen Browser', '󰈹'],
+        ['Mozilla zen', ''],
         ['Floorp', '󰈹'],
         ['(.*)', '󰝚'],
     ];

--- a/src/components/bar/modules/window_title/helpers/title.ts
+++ b/src/components/bar/modules/window_title/helpers/title.ts
@@ -61,6 +61,7 @@ export const getWindowMatch = (client: AstalHyprland.Client): Record<string, str
         ['thorium', '󰖟', 'Thorium'],
         ['tor-browser', '', 'Tor Browser'],
         ['floorp', '󰈹', 'Floorp'],
+        ['zen', '', 'Zen Browser'],
 
         // Terminals
         ['gnome-terminal', '', 'GNOME Terminal'],


### PR DESCRIPTION
Hi, I recently started using Zen Browser and noticed two issues:

1. There's no specific icon assigned to Zen Browser on window titles.
2. On media wasn't showing the icon because AstalMpris was returning "Mozilla zen" as the player name, while the entry expected "Zen Browser". I fixed this by updating the entry.

Regarding the icon change, I noticed that Media was using the Firefox icon (which makes sense). However, I changed it to [vscode-codicon-target](https://composeicons.com/icons/vscode-codicon/target) (included in Nerd Fonts), as it closely resembles the official icon on [Zen Browser's website.](https://zen-browser.app/)
