### PR TITLE
fix: scaled width and height on recording

### DIFF
--- a/scripts/screen_record.sh
+++ b/scripts/screen_record.sh
@@ -29,9 +29,12 @@ startRecording() {
         monitor_info=$(hyprctl -j monitors | jq -r ".[] | select(.name == \"$3\")")
         w=$(echo $monitor_info | jq -r '.width')
         h=$(echo $monitor_info | jq -r '.height')
+        scale=$(echo $monitor_info | jq -r '.scale')
+        scaled_width=$(echo "${w} / ${scale}" | bc)
+        scaled_height=$(echo "${h} / ${scale}" | bc)
         x=$(echo $monitor_info | jq -r '.x')
         y=$(echo $monitor_info | jq -r '.y')
-        wf-recorder $WF_RECORDER_OPTS --geometry "${x},${y} ${w}x${h}" --file "$outputPath" &
+        wf-recorder $WF_RECORDER_OPTS --geometry "${x},${y} ${scaled_width}x${scaled_height}" --file "$outputPath" &
     elif [ "$target" == "region" ]; then
         wf-recorder $WF_RECORDER_OPTS --geometry "$(slurp)" --file "$outputPath" &
     else


### PR DESCRIPTION
# Issue
when 2 monitors are connected and one of them is scaled (e.g. 1.5), recording button doesn't do anything

```bash
Failed to detect output based on geometry (is your geometry overlapping outputs?)
```

This would work with `slurp -o -d`

# Solution

make sure geometry is identical to `slurp` implementation by extracting scale from `hyprctl monitors`

* depends on `bc`