### PR TITLE
Fix: Prevent Matugen to override user settings with config defaults

### DIFF
--- a/src/scss/style.ts
+++ b/src/scss/style.ts
@@ -55,14 +55,14 @@ async function extractMatugenizedVariables(matugenColors: MatugenColors): Promis
                 continue;
             }
 
-            const initialValue = opt.value ?? opt.initial;
+            const value = opt.value;
 
-            if (!isHexColor(initialValue) && matugenColors !== undefined) {
-                result.push(`$${name.replace('theme.', '').split('.').join('-')}: ${initialValue};`);
+            if (!isHexColor(value) && matugenColors !== undefined) {
+                result.push(`$${name.replace('theme.', '').split('.').join('-')}: ${value};`);
                 continue;
             }
 
-            const matugenColor = getMatugenHex(initialValue as HexColor, matugenColors);
+            const matugenColor = getMatugenHex(value as HexColor, matugenColors);
 
             result.push(`$${name.replace('theme.', '').split('.').join('-')}: ${matugenColor};`);
         }

--- a/src/scss/style.ts
+++ b/src/scss/style.ts
@@ -55,7 +55,7 @@ async function extractMatugenizedVariables(matugenColors: MatugenColors): Promis
                 continue;
             }
 
-            const initialValue = opt.initial;
+            const initialValue = opt.value ?? opt.initial;
 
             if (!isHexColor(initialValue) && matugenColors !== undefined) {
                 result.push(`$${name.replace('theme.', '').split('.').join('-')}: ${initialValue};`);


### PR DESCRIPTION
Fixes issue #848 

Previously, the function used opt.initial to determine the theme variable values. However, opt.initial always holds the default value, causing user-defined settings to be overwritten when enabling Matugenized colors.

These changes to the function prioritize opt.value (if available) over opt.initial. This ensures that existing user configurations are preserved while still allowing Matugen colors to be applied correctly.

Co-Authored-by: @PhoenixGamer339