### PR TITLE
Add optional extended tooltip for updates module

### DIFF
--- a/scripts/checkUpdates.sh
+++ b/scripts/checkUpdates.sh
@@ -1,49 +1,87 @@
 #!/bin/bash
 
-check_arch_updates() {
-    official_updates=0
-    aur_updates=0
-	if command -v paru &> /dev/null; then
-		aur_helper="paru"
-	else
-		aur_helper="yay"
-	fi
+has_param() {
+    local term="$1"
+    shift
+    for arg; do
+        if [[ $arg == "$term" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
 
-    if [ "$1" = "-y" ]; then
-        aur_updates=$($aur_helper -Qum 2>/dev/null | wc -l)
-    elif [ "$1" = "-p" ]; then
-        official_updates=$(checkupdates 2>/dev/null | wc -l)
+check_arch_updates() {
+    if command -v paru &> /dev/null; then
+        aur_helper="paru"
     else
-        official_updates=$(checkupdates 2>/dev/null | wc -l)
-        aur_updates=$($aur_helper -Qum 2>/dev/null | wc -l)
+        aur_helper="yay"
     fi
 
-    total_updates=$((official_updates + aur_updates))
+    if has_param "-tooltip" "$@"; then
+        command=" | head -n 50"
+        official_updates=""
+        aur_updates=""
+        sleep 1 # if you use the checkupdates command again too quickly, it will not return anything
+    else
+        command="2>/dev/null | wc -l"
+        official_updates=0
+        aur_updates=0
+    fi
 
-    echo $total_updates
+    aur_command="$aur_helper -Qum $command"
+    official_command="checkupdates $command"
+
+    if has_param "-y" "$@"; then
+        aur_updates=$(eval "$aur_command")
+    elif has_param "-p" "$@"; then
+        official_updates=$(eval "$official_command")
+    else
+        aur_updates=$(eval "$aur_command")
+        official_updates=$(eval "$official_command")
+    fi
+
+    if has_param "-tooltip" "$@"; then
+        if [ "$official_updates" ];then
+            echo "pacman:"
+            echo "$official_updates"
+        fi
+        if [ "$official_updates" ] && [ "$aur_updates" ];then
+            echo ""
+        fi
+        if [ "$aur_updates" ];then
+            echo "AUR:"
+            echo "$aur_updates"
+        fi
+    else
+        total_updates=$((official_updates + aur_updates))
+        echo $total_updates
+    fi
+
+
 }
 
 check_ubuntu_updates() {
-  result=$(apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst)
-  echo "$result"
+    result=$(apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst)
+    echo "$result"
 }
 
 check_fedora_updates() {
-  result=$(dnf check-update -q | grep -v '^Loaded plugins' | grep -v '^No match for' | wc -l)
-  echo "$result"
+    result=$(dnf check-update -q | grep -v '^Loaded plugins' | grep -v '^No match for' | wc -l)
+    echo "$result"
 }
 
 case "$1" in
--arch)
-    check_arch_updates "$2"
-    ;;
--ubuntu)
-    check_ubuntu_updates
-    ;;
--fedora)
-    check_fedora_updates
-    ;;
-*)
-    echo "0"
-    ;;
+    -arch)
+        check_arch_updates "$2" "$3"
+        ;;
+    -ubuntu)
+        check_ubuntu_updates
+        ;;
+    -fedora)
+        check_fedora_updates
+        ;;
+    *)
+        echo "0"
+        ;;
 esac

--- a/scripts/checkUpdates.sh
+++ b/scripts/checkUpdates.sh
@@ -29,7 +29,7 @@ check_arch_updates() {
         command=" | head -n 50"
         official_updates=""
         aur_updates=""
-        sleep 1 # if you use the checkupdates command again too quickly, it will not return anything
+        wait_for_process_to_finish "checkupdates"
     else
         command="2>/dev/null | wc -l"
         official_updates=0

--- a/scripts/checkUpdates.sh
+++ b/scripts/checkUpdates.sh
@@ -11,6 +11,13 @@ has_param() {
     return 1
 }
 
+wait_for_process_to_finish() {
+    local process_name="$1"
+    while pgrep -a "$process_name" >/dev/null; do 
+        sleep 0.1
+    done
+}
+
 check_arch_updates() {
     if command -v paru &> /dev/null; then
         aur_helper="paru"

--- a/src/components/bar/modules/updates/index.tsx
+++ b/src/components/bar/modules/updates/index.tsx
@@ -33,9 +33,9 @@ const processUpdateCount = (updateCount: string): string => {
 };
 
 const processUpdateTooltip = (updateTooltip: string, updateCount: Variable<string>): string => {
-    let defaultTooltip = updateCount.get() + " updates available";
+    const defaultTooltip = updateCount.get() + ' updates available';
     if (!extendedTooltip.get()) return defaultTooltip;
-    return defaultTooltip + "\n\n" + updateTooltip;
+    return defaultTooltip + '\n\n' + updateTooltip;
 };
 
 const updatesPoller = new BashPoller<string, []>(
@@ -52,7 +52,7 @@ const tooltipPoller = new BashPoller<string, [Variable<string>]>(
     bind(pollingInterval),
     updateTooltipCommand.get(),
     processUpdateTooltip,
-    pendingUpdates
+    pendingUpdates,
 );
 
 updatesPoller.initialize('updates');

--- a/src/components/bar/settings/config.tsx
+++ b/src/components/bar/settings/config.tsx
@@ -238,6 +238,17 @@ export const CustomModuleSettings = (): JSX.Element => {
                     type="string"
                 />
                 <Option
+                    opt={options.bar.customModules.updates.updateTooltipCommand}
+                    title="Check Updates Tooltip Command"
+                    type="string"
+                />
+                <Option
+                    opt={options.bar.customModules.updates.extendedTooltip}
+                    title="Show Extended Tooltip"
+                    subtitle="Lists packages with updates. Arch only."
+                    type="boolean"
+                />
+                <Option
                     opt={options.bar.customModules.updates.icon.pending}
                     title="Updates Available Icon"
                     type="string"

--- a/src/options.ts
+++ b/src/options.ts
@@ -1142,6 +1142,8 @@ const options = mkOptions({
             },
             updates: {
                 updateCommand: opt(`${SRC_DIR}/scripts/checkUpdates.sh -arch`),
+                updateTooltipCommand: opt(`${SRC_DIR}/scripts/checkUpdates.sh -arch -tooltip`),
+                extendedTooltip: opt(false),
                 label: opt(true),
                 padZero: opt(true),
                 autoHide: opt(false),


### PR DESCRIPTION
I was missing this functionality after swapping from waybar to HyprPanel, so i tried my hand at implementing it myself.

This will optionally show a list of updated packages when hovering the updates module. I set the toggle to off by default to not change existing configs. Here is a preview:

![image](https://github.com/user-attachments/assets/69e98f4c-b8b7-4ee5-a861-8721b28dfd32)

When disabled, it will show the old tool-tip same as before:

![image](https://github.com/user-attachments/assets/52e67ccd-19c4-42bc-b1b6-056f0d7e8097)

I tried to not break compatibility with any existing previous configs which might contain custom scripts. 

One thing i am not quite happy with is that i needed to add a sleep between pacmans _checkupdate_ calls, as it will not return anything if you use it again too quickly. I debated over changing more of the existing code to enable me calling it only once, but in the end I settled for the sleep as it results in the least amount of changes overall and works perfectly fine. Changing the behavior of the _checkUpdates.sh_ further would also likely break compatibility with existing user scripts.

I'm happy to implement a better way of doing it though if someone can come up with one.

Also this is my first open-source PR and my first time using TypeScript, so if i missed anything obvious please tell me as well!

