### PR TITLE
Fix: Stable update info polling

### DIFF
--- a/scripts/checkUpdates.sh
+++ b/scripts/checkUpdates.sh
@@ -13,9 +13,13 @@ has_param() {
 
 wait_for_process_to_finish() {
     local process_name="$1"
-    while pgrep -a "$process_name" >/dev/null; do 
-        sleep 0.1
+    local pid
+
+    while pid=$(pgrep -x "$process_name"); do
+        wait "$pid" 2>/dev/null || true
     done
+
+    sleep 2
 }
 
 check_arch_updates() {

--- a/src/components/bar/modules/updates/index.tsx
+++ b/src/components/bar/modules/updates/index.tsx
@@ -34,7 +34,7 @@ const processUpdateCount = (updateCount: string): string => {
 
 const processUpdateTooltip = (updateTooltip: string, updateCount: Variable<string>): string => {
     const defaultTooltip = updateCount.get() + ' updates available';
-    if (!extendedTooltip.get()) return defaultTooltip;
+    if (!extendedTooltip.get() || !updateTooltip) return defaultTooltip;
     return defaultTooltip + '\n\n' + updateTooltip;
 };
 


### PR DESCRIPTION
This is further optimization of #866. 

I rewrote the polling part so that it only polls once with both the normal and the extended tooltip setting. 

The previous implementation relied on waiting between two _checkupdate_ calls for a certain amount of time, as calling them back to back too quickly made the second call return nothing. This approach of waiting until the first process finished was often not enough to reliably get the second call to return data. Now there will only ever be one call per polling interval, ensuring that it will always work properly.

I also noticed the _stop()_ function of the _Poller_ class didn't actually stop the execution of the poller, so i added an _isActive_ flag to ensure the poller stops running.


