### PR TITLE
Fix notifications menu border rounding

### DIFF
--- a/src/components/menus/notifications/index.tsx
+++ b/src/components/menus/notifications/index.tsx
@@ -22,7 +22,7 @@ export default (): JSX.Element => {
                 curPage.drop();
             }}
         >
-            <box className={'notification-menu-content'} css={'padding: 1px; margin: -1px;'} hexpand vexpand>
+            <box className={'notification-menu-content'} hexpand vexpand>
                 <box className={'notification-card-container menu'} hexpand vexpand vertical>
                     <Controls />
                     <NotificationsContainer curPage={curPage} />

--- a/src/scss/style/menus/notifications.scss
+++ b/src/scss/style/menus/notifications.scss
@@ -208,6 +208,7 @@
 
 .notification-menu-pager {
     background: $bar-menus-menu-notifications-pager-background;
+    margin-bottom: 0.1em;
     border-radius: $bar-menus-border-radius;
     border-top-left-radius: 0em;
     border-top-right-radius: 0em;


### PR DESCRIPTION
Before 
![image](https://github.com/user-attachments/assets/0f7923b4-2d2e-4ce8-8328-28d468fd5153)

After:
![image](https://github.com/user-attachments/assets/9548261d-518c-4496-bf20-d8d499dd9814)

This would only happen when the paging buttons didnt show up

Closes #843