### PR TITLE
fix(dashboard): dont show margins around disabled sections

### DIFF
--- a/src/components/menus/dashboard/controls/index.tsx
+++ b/src/components/menus/dashboard/controls/index.tsx
@@ -9,7 +9,7 @@ import {
 
 export const Controls = ({ isEnabled }: ControlsProps): JSX.Element => {
     if (!isEnabled) {
-        return <box />;
+        return null;
     }
 
     return (

--- a/src/components/menus/dashboard/directories/index.tsx
+++ b/src/components/menus/dashboard/directories/index.tsx
@@ -4,7 +4,7 @@ import { LeftLink1, LeftLink2, LeftLink3, RightLink1, RightLink2, RightLink3 } f
 
 export const Directories = ({ isEnabled }: DirectoriesProps): JSX.Element => {
     if (!isEnabled) {
-        return <box />;
+        return null;
     }
 
     return (

--- a/src/components/menus/dashboard/shortcuts/index.tsx
+++ b/src/components/menus/dashboard/shortcuts/index.tsx
@@ -6,7 +6,7 @@ export const Shortcuts = ({ isEnabled }: ShortcutsProps): JSX.Element => {
     recordingPoller.initialize();
 
     if (!isEnabled) {
-        return <box />;
+        return null;
     }
 
     return (

--- a/src/components/menus/dashboard/stats/index.tsx
+++ b/src/components/menus/dashboard/stats/index.tsx
@@ -15,7 +15,7 @@ initializePollers(cpuService, ramService, gpuService, storageService);
 
 export const Stats = ({ isEnabled }: StatsProps): JSX.Element => {
     if (!isEnabled) {
-        return <box />;
+        return null;
     }
 
     return (


### PR DESCRIPTION
Currently there are margins shown around disabled sections, causing the margin to be doubled.
This PR fixes this issue.

## Current state
```
{
  "menus.dashboard.controls.enabled": true,
  "menus.dashboard.shortcuts.enabled": true,
  "menus.dashboard.directories.enabled": false
}
```
![image](https://github.com/user-attachments/assets/fe3690d0-133b-4f9a-be78-ffff07be8390)

## After fix

![image](https://github.com/user-attachments/assets/7df7b30c-e01f-4166-a312-e936a13f9bb9)

