### PR TITLE
remove full path /bin/bash in helpers.ts

### DIFF
--- a/src/components/menus/dashboard/shortcuts/helpers.ts
+++ b/src/components/menus/dashboard/shortcuts/helpers.ts
@@ -20,7 +20,7 @@ export const getRecordingPath = (): string => options.menus.dashboard.recording.
  */
 export const executeCommand = async (command: string): Promise<void> => {
     try {
-        await execAsync(`/bin/bash -c '${command}'`);
+        await execAsync(`bash -c '${command}'`);
     } catch (err) {
         console.error('Command failed:', command);
         console.error('Error:', err);


### PR DESCRIPTION
Prior to this screen recording would fail on nixos as there is no `/bin/bash`.

I assume the full path was never needed as `handleClick` in the same helpers.ts file also just calls `bash`.