### PR TITLE
Remove hard dependency on overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,28 +155,40 @@ If you install the fonts after installing HyperPanel, you will need to restart H
 ### NixOS & Home-Manager
 
 Alternatively, if you're using NixOS and/or Home-Manager, you can setup AGS using the provided Nix Flake. First, add the repository to your Flake's inputs, and enable the overlay.
+You can now also just use wrapper as the package directly and ignore this section almost entirely (expect for adding inputs), it's recommended to avoid overlays.
 
 ```nix
 # flake.nix
 
 {
-  inputs.hyprpanel.url = "github:Jas-SinghFSU/HyprPanel";
-  # ...
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    hyprpanel = {
+      url = "github:Jas-SinghFSU/HyprPanel";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-  outputs = { self, nixpkgs, ... }@inputs:
-  let
-    # ...
- system = "x86_64-linux"; # change to whatever your system should be.
-    pkgs = import nixpkgs {
-   inherit system;
-   # ...
-   overlays = [
+  outputs =
+    { self, nixpkgs, ... }@inputs:
+    let
+      overlays = [
         inputs.hyprpanel.overlay
-   ];
- };
-  in {
-    # ...
-  }
+      ];
+    in
+    {
+      nixosConfigurations = {
+        nixos = nixpkgs.lib.nixosSystem {
+          specialArgs = {
+            inherit inputs;
+          };
+          modules = [
+            ./configuration.nix
+            { nixpkgs.overlays = [ overlays ]; }
+          ];
+        };
+      };
+    };
 }
 ```
 
@@ -188,6 +200,7 @@ Once you've set up the overlay, you can reference HyprPanel with `pkgs.hyprpanel
 # install it as a system package
 environment.systemPackages = with pkgs; [
   # ...
+  inputs.hyprpanel.packages.${pkgs.system}.wrapper # this one if you want to avoid overlays/didn't enable them
   hyprpanel
   # ...
 ];
@@ -195,6 +208,7 @@ environment.systemPackages = with pkgs; [
 # or install it as a user package
 users.users.<username>.packages = with pkgs; [
   # ...
+  inputs.hyprpanel.packages.${pkgs.system}.wrapper # this one if you want to avoid overlays/didn't enable them
   hyprpanel
   # ...
 ];
@@ -205,6 +219,7 @@ users.users.<username>.packages = with pkgs; [
 # install it as a user package with home-manager
 home.packages = with pkgs; [
   # ...
+  inputs.hyprpanel.packages.${pkgs.system}.wrapper # this one if you want to avoid overlays/didn't enable them
   hyprpanel
   # ...
 ];
@@ -212,6 +227,7 @@ home.packages = with pkgs; [
 # or reference it directly in your Hyprland configuration
 wayland.windowManager.hyprland.settings.exec-once = [
   "${pkgs.hyprpanel}/bin/hyprpanel"
+  "${inputs.hyprpanel.packages.${pkgs.system}.wrapper}/bin/hyprpanel" # this one if you want to avoid overlays/didn't enable them
 ];
 
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -8,84 +8,103 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    ags,
-  }: let
-    systems = ["x86_64-linux" "aarch64-linux"];
-    forEachSystem = nixpkgs.lib.genAttrs systems;
-  in {
-    packages = forEachSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      default = ags.lib.bundle {
-        inherit pkgs;
-        src = ./.;
-        name = "hyprpanel"; # name of executable
-        entry = "app.ts";
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ags,
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forEachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = ags.lib.bundle {
+            inherit pkgs;
+            src = ./.;
+            name = "hyprpanel"; # name of executable
+            entry = "app.ts";
 
-        extraPackages =
-          (with ags.packages.${system}; [
-            tray
-            hyprland
-            apps
-            battery
-            bluetooth
-            mpris
-            cava
-            network
-            notifd
-            powerprofiles
-            wireplumber
-          ])
-          ++ (with pkgs; [
-            fish
-            typescript
-            libnotify
-            dart-sass
-            fd
-            btop
-            bluez
-            libgtop
-            gobject-introspection
-            glib
-            bluez-tools
-            grimblast
-            brightnessctl
-            gnome-bluetooth
-            (python3.withPackages (ps:
-              with ps; [
-                gpustat
-                dbus-python
-                pygobject3
-              ]))
-            matugen
-            hyprpicker
-            hyprsunset
-            hypridle
-            wireplumber
-            networkmanager
-            wf-recorder
-            upower
-            gvfs
-            swww
-            pywal
-          ]);
+            extraPackages =
+              (with ags.packages.${system}; [
+                tray
+                hyprland
+                apps
+                battery
+                bluetooth
+                mpris
+                cava
+                network
+                notifd
+                powerprofiles
+                wireplumber
+              ])
+              ++ (with pkgs; [
+                fish
+                typescript
+                libnotify
+                dart-sass
+                fd
+                btop
+                bluez
+                libgtop
+                gobject-introspection
+                glib
+                bluez-tools
+                grimblast
+                brightnessctl
+                gnome-bluetooth
+                (python3.withPackages (
+                  ps: with ps; [
+                    gpustat
+                    dbus-python
+                    pygobject3
+                  ]
+                ))
+                matugen
+                hyprpicker
+                hyprsunset
+                hypridle
+                wireplumber
+                networkmanager
+                wf-recorder
+                upower
+                gvfs
+                swww
+                pywal
+              ]);
+          };
+          # Make a wrapper package to avoid overlay
+          wrapper = pkgs.writeShellScriptBin "hyprpanel" ''
+            if [ "$#" -eq 0 ]; then
+                exec ${self.packages.${pkgs.stdenv.system}.default}/bin/hyprpanel
+            else
+                exec ${ags.packages.${pkgs.stdenv.system}.io}/bin/astal -i hyprpanel "$*"
+            fi
+          '';
+        }
+      );
+
+      # Define .overlay to expose the package as pkgs.hyprpanel based on the system
+      overlay = final: prev: {
+        hyprpanel = prev.writeShellScriptBin "hyprpanel" ''
+          if [ "$#" -eq 0 ]; then
+              exec ${self.packages.${final.stdenv.system}.default}/bin/hyprpanel
+          else
+              exec ${ags.packages.${final.stdenv.system}.io}/bin/astal -i hyprpanel "$*"
+          fi
+        '';
       };
-    });
 
-    # Define .overlay to expose the package as pkgs.hyprpanel based on the system
-    overlay = final: prev: {
-      hyprpanel = prev.writeShellScriptBin "hyprpanel" ''
-        if [ "$#" -eq 0 ]; then
-            exec ${self.packages.${final.stdenv.system}.default}/bin/hyprpanel
-        else
-            exec ${ags.packages.${final.stdenv.system}.io}/bin/astal -i hyprpanel "$*"
-        fi
-      '';
+      homeManagerModules.hyprpanel = import ./nix/module.nix self;
     };
-
-    homeManagerModules.hyprpanel = import ./nix/module.nix self;
-  };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -22,18 +22,7 @@ let
     if pkgs ? hyprpanel then
       pkgs.hyprpanel
     else
-      abort ''
-
-        ********************************************************************************
-        *                                  HyprPanel                                   *
-        *------------------------------------------------------------------------------*
-        *                         You didn't add the overlay!                          *
-        *                                                                              *
-        * Either set 'overlay.enable = true' or manually add it to 'nixpkgs.overlays'. *
-        * If you use the 'nixosModule' for Home Manager and have 'useGlobalPkgs' set,  *
-        *                  you will need to add the overlay yourself.                  *
-        ********************************************************************************
-      '';
+      self.packages.${pkgs.stdenv.system}.wrapper;
 
   # Shorthand lambda for self-documenting options under settings
   mkStrOption =


### PR DESCRIPTION
Overlays are not recommended and take up more ram and time during evaluation
I also ran flake.nix through nixfmt