### PR TITLE
fix: initialize media players on startup

### DIFF
--- a/src/services/media/index.ts
+++ b/src/services/media/index.ts
@@ -57,6 +57,10 @@ export class MediaPlayerService {
 
         this.mediaTitle.set(noMediaText.get());
 
+        for (const player of this._mprisService.players) {
+            this._handlePlayerAdded(player);
+        }
+
         this._mprisService.connect('player-closed', (_, closedPlayer) =>
             this._handlePlayerClosed(closedPlayer),
         );

--- a/src/services/media/index.ts
+++ b/src/services/media/index.ts
@@ -57,7 +57,7 @@ export class MediaPlayerService {
 
         this.mediaTitle.set(noMediaText.get());
 
-        for (const player of this._mprisService.players) {
+        for (const player of this._mprisService.get_players()) {
             this._handlePlayerAdded(player);
         }
 


### PR DESCRIPTION
They were previously not being loaded until they were seen for the first time