### PR TITLE
feat: add ability to specify connector as layout name and extend other layouts

### DIFF
--- a/src/components/bar/utils/monitors/index.ts
+++ b/src/components/bar/utils/monitors/index.ts
@@ -3,6 +3,13 @@ import { BarLayout, BarLayouts } from 'src/lib/options/types';
 import { GdkMonitorService } from 'src/services/display/monitor';
 import { MonitorMapping } from './types';
 import { JSXElement } from 'src/core/types';
+import AstalHyprland from 'gi://AstalHyprland?version=0.1';
+
+const emptyBar = {
+    left: [],
+    middle: [],
+    right: [],
+};
 
 /**
  * Returns the bar layout configuration for a specific monitor
@@ -12,22 +19,78 @@ import { JSXElement } from 'src/core/types';
  * @returns BarLayout configuration for the specified monitor, falling back to default if not found
  */
 export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLayout => {
-    const matchingKey = Object.keys(layouts).find((key) => key === monitor.toString());
-    const wildcard = Object.keys(layouts).find((key) => key === '*');
+    const [rootKey, rootLayout] = _getResolveLayoutCopy(monitor, layouts);
 
-    if (matchingKey !== undefined) {
-        return layouts[matchingKey];
-    }
+    let left = rootLayout.left;
+    let middle = rootLayout.middle;
+    let right = rootLayout.right;
 
-    if (wildcard) {
-        return layouts[wildcard];
+    let layout = rootLayout;
+    const visited = new Array([rootKey]);
+    while (
+        layout.extends !== undefined &&
+        (left === undefined || middle === undefined || right.length === undefined)
+    ) {
+        if (visited.includes(layout.extends)) {
+            console.error(`found circular reference in layout extensions: ${visited.join(' -> ')}`);
+            return emptyBar;
+        }
+        visited.push(layout.extends);
+
+        if (!(layout.extends in layouts)) {
+            console.error(
+                `failed to find layout with name '${layout.extends}' (resolved path: ${visited.join(' -> ')})`,
+            );
+            return emptyBar;
+        }
+
+        layout = layouts[layout.extends];
+
+        if (left === undefined) {
+            left = layout.left;
+        }
+        if (middle === undefined) {
+            middle = layout.middle;
+        }
+        if (right === undefined) {
+            right = layout.right;
+        }
     }
 
     return {
-        left: ['dashboard', 'workspaces', 'windowtitle'],
-        middle: ['media'],
-        right: ['volume', 'network', 'bluetooth', 'battery', 'systray', 'clock', 'notifications'],
+        left: left ?? [],
+        middle: middle ?? [],
+        right: right ?? [],
     };
+};
+
+const _getResolveLayoutCopy = (monitor: number, layouts: BarLayouts): [string, BarLayout] => {
+    const hyprlandService = AstalHyprland.get_default();
+    const monitorConn = hyprlandService.get_monitor(monitor).get_name();
+
+    const matchingConn = Object.keys(layouts).find((key) => key === monitorConn);
+    if (matchingConn !== undefined) {
+        return [matchingConn, layouts[matchingConn]];
+    }
+
+    const matchingNum = Object.keys(layouts).find((key) => key === monitor.toString());
+    if (matchingNum !== undefined) {
+        return [matchingNum, layouts[matchingNum]];
+    }
+
+    const wildcard = Object.keys(layouts).find((key) => key === '*');
+    if (wildcard) {
+        return [wildcard, layouts[wildcard]];
+    }
+
+    return [
+        'default',
+        {
+            left: ['dashboard', 'workspaces', 'windowtitle'],
+            middle: ['media'],
+            right: ['volume', 'network', 'bluetooth', 'battery', 'systray', 'clock', 'notifications'],
+        },
+    ];
 };
 
 /**

--- a/src/components/bar/utils/monitors/index.ts
+++ b/src/components/bar/utils/monitors/index.ts
@@ -26,7 +26,7 @@ export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLa
     let right = rootLayout.right;
 
     let layout = rootLayout;
-    const visited = new Array([rootKey]);
+    const visited = [rootKey];
     while (
         layout.extends !== undefined &&
         (left === undefined || middle === undefined || right.length === undefined)

--- a/src/components/bar/utils/monitors/index.ts
+++ b/src/components/bar/utils/monitors/index.ts
@@ -19,7 +19,7 @@ const emptyBar = {
  * @returns BarLayout configuration for the specified monitor, falling back to default if not found
  */
 export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLayout => {
-    const [rootKey, rootLayout] = _getResolveLayoutCopy(monitor, layouts);
+    const [rootKey, rootLayout] = _getResolveLayoutForMonitor(monitor, layouts);
 
     let left = rootLayout.left;
     let middle = rootLayout.middle;
@@ -64,7 +64,7 @@ export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLa
     };
 };
 
-const _getResolveLayoutCopy = (monitor: number, layouts: BarLayouts): [string, BarLayout] => {
+const _getResolveLayoutForMonitor = (monitor: number, layouts: BarLayouts): [string, BarLayout] => {
     const hyprlandService = AstalHyprland.get_default();
     const monitorConn = hyprlandService.get_monitor(monitor).get_name();
 

--- a/src/components/bar/utils/monitors/index.ts
+++ b/src/components/bar/utils/monitors/index.ts
@@ -29,7 +29,7 @@ export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLa
     const visited = [rootKey];
     while (
         layout.extends !== undefined &&
-        (left === undefined || middle === undefined || right.length === undefined)
+        (left === undefined || middle === undefined || right === undefined)
     ) {
         if (visited.includes(layout.extends)) {
             console.error(`found circular reference in layout extensions: ${visited.join(' -> ')}`);

--- a/src/lib/bar/helpers.ts
+++ b/src/lib/bar/helpers.ts
@@ -16,9 +16,9 @@ export function getLayoutItems(): BarModule[] {
     const itemsInLayout: BarModule[] = [];
 
     Object.keys(layouts.get()).forEach((monitor) => {
-        const leftItems = layouts.get()[monitor].left;
-        const rightItems = layouts.get()[monitor].right;
-        const middleItems = layouts.get()[monitor].middle;
+        const leftItems = layouts.get()[monitor].left ?? [];
+        const rightItems = layouts.get()[monitor].right ?? [];
+        const middleItems = layouts.get()[monitor].middle ?? [];
 
         itemsInLayout.push(...leftItems);
         itemsInLayout.push(...middleItems);

--- a/src/lib/options/types.ts
+++ b/src/lib/options/types.ts
@@ -46,6 +46,7 @@ export type BarLayout = {
     left: BarModule[];
     middle: BarModule[];
     right: BarModule[];
+    extends: string?;
 };
 export type BarLayouts = {
     [key: string]: BarLayout;

--- a/src/lib/options/types.ts
+++ b/src/lib/options/types.ts
@@ -46,7 +46,7 @@ export type BarLayout = {
     left: BarModule[];
     middle: BarModule[];
     right: BarModule[];
-    extends: string?;
+    extends?: string;
 };
 export type BarLayouts = {
     [key: string]: BarLayout;

--- a/src/services/display/monitor/index.ts
+++ b/src/services/display/monitor/index.ts
@@ -60,7 +60,7 @@ export class GdkMonitorService {
         const tempUsedIds = new Set<number>();
         const monitorsToUse = validMonitors.length > 0 ? validMonitors : hyprlandMonitors;
 
-        const result = this._matchMonitor(
+        return this._matchMonitor(
             monitorsToUse,
             gdkMonitor,
             monitor,
@@ -68,8 +68,6 @@ export class GdkMonitorService {
             (mon, gdkMon) => this._matchMonitorKey(mon, gdkMon),
             tempUsedIds,
         );
-
-        return result;
     }
 
     /**


### PR DESCRIPTION
Some example configuration of what is now possible:
```json
  "bar.layouts": {
    "base": {
      "left": ["workspaces"],
      "middle": ["cava"],
      "right": [
        "volume",
        "network",
        "bluetooth",
        "clock",
        "notifications",
        "hypridle",
        "power"
      ]
    },
    "DP-2": {
      "extends": "base"
    },
    "eDP-1": {
      "extends": "base",
      "right": [
        "volume",
        "network",
        "bluetooth",
        "battery",
        "clock",
        "notifications",
        "hypridle",
        "power"
      ]
    },
    "*": {
      "left": ["workspaces"],
      "right": ["volume", "clock", "notifications"]
    }
  },
```

This configuration will reuse the same "base" layout for both `eDP-1` (connector of my laptop display) and `DP-2` (my main display for my desktop), and I can override the right part of the layout for `eDP-1` to add the battery module.