### PR TITLE
Fix: Export glib-networking modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,13 +102,13 @@
               # Exporting glib-networking modules
               export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules"
               if [ "''${PWD##*/}" = "HyprPanel" ]; then
-                echo "do you want to initialise stuff in order for tsserver to work? (y/anything_else)"
+                echo "Initialise dependencies required in order for tsserver to work? (y/anything_else)"
                 read consent
                 if [ "$consent" = "y" ]; then
                   ags types -d .; mkdir node_modules; ln -s ${astal.packages.${system}.gjs}/share/astal/gjs ./node_modules/astal
                 fi
               else
-                echo "you're not in HyprPanel root dir, no initialisation for you"
+                echo "You're not in the HyprPanel root directory, initialisation failed"
               fi
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -99,15 +99,17 @@
                 ninja
               ];
             shellHook = ''
-            if [ "''${PWD##*/}" = "HyprPanel" ]; then
-              echo "do you want to initialise stuff in order for tsserver to work? (y/anything_else)"
-              read consent
-              if [ "$consent" = "y" ]; then
-                ags types -d .; mkdir node_modules; ln -s ${astal.packages.${system}.gjs}/share/astal/gjs ./node_modules/astal
+              # Exporting glib-networking modules
+              export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules"
+              if [ "''${PWD##*/}" = "HyprPanel" ]; then
+                echo "do you want to initialise stuff in order for tsserver to work? (y/anything_else)"
+                read consent
+                if [ "$consent" = "y" ]; then
+                  ags types -d .; mkdir node_modules; ln -s ${astal.packages.${system}.gjs}/share/astal/gjs ./node_modules/astal
+                fi
+              else
+                echo "you're not in HyprPanel root dir, no initialisation for you"
               fi
-            else
-              echo "you're not in HyprPanel root dir, no initialisation for you"
-            fi
             '';
           };
         }
@@ -129,10 +131,12 @@
           };
           # Make a wrapper package to avoid overlay
           wrapper = pkgs.writeShellScriptBin "hyprpanel" ''
+            # Exporting glib-networking modules
+            export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules"
             if [ "$#" -eq 0 ]; then
                 exec ${self.packages.${pkgs.stdenv.system}.default}/bin/hyprpanel
             else
-                exec ${ags.packages.${pkgs.stdenv.system}.io}/bin/astal -i hyprpanel "$*"
+                exec ${ags.packages.${pkgs.stdenv.system}.io}/bin/astal -i hyprpanel "$@"
             fi
           '';
         }
@@ -144,7 +148,7 @@
           if [ "$#" -eq 0 ]; then
               exec ${self.packages.${final.stdenv.system}.default}/bin/hyprpanel
           else
-              exec ${ags.packages.${final.stdenv.system}.io}/bin/astal -i hyprpanel "$*"
+              exec ${ags.packages.${final.stdenv.system}.io}/bin/astal -i hyprpanel "$@"
           fi
         '';
       };


### PR DESCRIPTION
Export GIO networking modules in development and wrapper scripts. Closes #982.
