### PR TITLE
fix(monitor): 🐛 add check for undefined hyprlandMonitor to avoid MonitorRefresh crash

### DIFF
--- a/src/services/display/monitor/index.ts
+++ b/src/services/display/monitor/index.ts
@@ -164,7 +164,11 @@ export class GdkMonitorService {
      * @returns boolean indicating if the monitors match
      */
     private _matchMonitorKey(hyprlandMonitor: AstalHyprland.Monitor, gdkMonitor: GdkMonitor): boolean {
-        if (!hyprlandMonitor?.model || hyprlandMonitor.model === null || hyprlandMonitor.model === undefined) {
+        if (
+            !hyprlandMonitor?.model ||
+            hyprlandMonitor.model === null ||
+            hyprlandMonitor.model === undefined
+        ) {
             return false;
         }
 

--- a/src/services/display/monitor/index.ts
+++ b/src/services/display/monitor/index.ts
@@ -164,7 +164,7 @@ export class GdkMonitorService {
      * @returns boolean indicating if the monitors match
      */
     private _matchMonitorKey(hyprlandMonitor: AstalHyprland.Monitor, gdkMonitor: GdkMonitor): boolean {
-        if (!hyprlandMonitor.model || hyprlandMonitor.model === 'null') {
+        if (!hyprlandMonitor?.model || hyprlandMonitor.model === null || hyprlandMonitor.model === undefined) {
             return false;
         }
 


### PR DESCRIPTION
Crashes when trying to take a screenshot of a monitor that is undefined.


```console
(gjs:108409): hyprpanel-CRITICAL **: 19:47:48.757: [MonitorRefresh] Error during component refresh: TypeError: hyprlandMonitor is undefined
_matchMonitorKey@file:///usr/share/hyprpanel/hyprpanel.js:16645:9
mapHyprlandToGdk/<@file:///usr/share/hyprpanel/hyprpanel.js:16594:44
_matchMonitor/directMatch<@file:///usr/share/hyprpanel/hyprpanel.js:16614:30
_matchMonitor@file:///usr/share/hyprpanel/hyprpanel.js:16613:36
mapHyprlandToGdk@file:///usr/share/hyprpanel/hyprpanel.js:16589:17
notifications_default5/windowMonitor<@file:///usr/share/hyprpanel/hyprpanel.js:24076:46
update@file:///usr/share/hyprpanel/hyprpanel.js:306:32
derive@file:///usr/share/hyprpanel/hyprpanel.js:307:38
notifications_default5@file:///usr/share/hyprpanel/hyprpanel.js:24072:34
_refreshMonitors@file:///usr/share/hyprpanel/hyprpanel.js:29819:7
async*handleMonitorChange/this._monitorChangeTimeout<@file:///usr/share/hyprpanel/hyprpanel.js:29796:12
setTimeout/source<@resource:///org/gnome/gjs/modules/esm/_timers.js:72:9
_init/GLib.MainLoop.prototype.runAsync/</<@resource:///org/gnome/gjs/modules/core/overrides/GLib.js:263:34
```