### PR TITLE
fix(scripts): update flatpak only if command exists

### DIFF
--- a/scripts/runUpdates.sh
+++ b/scripts/runUpdates.sh
@@ -15,7 +15,7 @@ install_arch_updates() {
     fi
     if command -v flatpak &> /dev/null; then
         echo "Updating Flatpak packages..."
-	flatpak update -y
+	      flatpak update -y
     fi
     echo "Done with Arch & AUR updates."
 }

--- a/scripts/runUpdates.sh
+++ b/scripts/runUpdates.sh
@@ -13,8 +13,10 @@ install_arch_updates() {
     else
         echo "Missing AUR Helper. Try installing yay or paru"
     fi
-    echo "Updating Flatpak packages..."
-    flatpak update -y
+    if command -v flatpak &> /dev/null; then
+        echo "Updating Flatpak packages..."
+	flatpak update -y
+    fi
     echo "Done with Arch & AUR updates."
 }
 


### PR DESCRIPTION
This PR adds a check in the runUpdates.sh script to only run the flatpak update -y command if the flatpak CLI is installed. Since Flatpak is not included by default on Arch Linux installations, this prevents errors during the update process when Flatpak is missing.

Changes:

    Added command -v flatpak check before running flatpak update -y.

Why:
Without this check, the update script fails if Flatpak is not installed, which can disrupt automated update workflows on Arch systems.