### PR TITLE
Fix for volume down issue #1010

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -325,8 +325,8 @@ in
       bar.volume.label = mkBoolOption true;
       bar.volume.middleClick = mkStrOption "";
       bar.volume.rightClick = mkStrOption "";
-      bar.volume.scrollDown = mkStrOption "${package}/bin/hyprpanel 'vol -5'";
-      bar.volume.scrollUp = mkStrOption "${package}/bin/hyprpanel 'vol +5'";
+      bar.volume.scrollDown = mkStrOption "${package}/bin/hyprpanel 'voldown 5'";
+      bar.volume.scrollUp = mkStrOption "${package}/bin/hyprpanel 'volup 5'";
       bar.windowtitle.class_name = mkBoolOption true;
       bar.windowtitle.custom_title = mkBoolOption true;
       bar.windowtitle.icon = mkBoolOption true;

--- a/src/configuration/modules/config/bar/volume/index.ts
+++ b/src/configuration/modules/config/bar/volume/index.ts
@@ -4,6 +4,6 @@ export default {
     label: opt(true),
     rightClick: opt(''),
     middleClick: opt(''),
-    scrollUp: opt('hyprpanel vol +5'),
-    scrollDown: opt('hyprpanel vol -5'),
+    scrollUp: opt('hyprpanel volup 5'),
+    scrollDown: opt('hyprpanel voldown 5'),
 };

--- a/src/services/cli/commander/commands/system/utility/index.ts
+++ b/src/services/cli/commander/commands/system/utility/index.ts
@@ -63,14 +63,14 @@ export const utilityCommands: Command[] = [
         },
     },
     {
-        name: 'adjustVolume',
-        aliases: ['vol'],
-        description: 'Adjusts the volume of the default audio output device.',
+        name: 'adjustVolumeUp',
+        aliases: ['volup'],
+        description: 'Increases the volume of the default audio output device.',
         category: 'System',
         args: [
             {
                 name: 'volume',
-                description: 'A positive or negative number to adjust the volume by.',
+                description: 'A number to increase the volume by.',
                 type: 'number',
                 required: true,
             },
@@ -89,6 +89,41 @@ export const utilityCommands: Command[] = [
                     speaker.set_volume(Math.min(speaker.volume + volumeInput, 1.5));
                 } else {
                     speaker.set_volume(Math.min(speaker.volume + volumeInput, 1));
+                }
+
+                return Math.round((speaker.volume + volumeInput) * 100);
+            } catch (error) {
+                errorHandler(error);
+            }
+        },
+    },
+    {
+        name: 'adjustVolumeDown',
+        aliases: ['voldown'],
+        description: 'Decreases the volume of the default audio output device.',
+        category: 'System',
+        args: [
+            {
+                name: 'volume',
+                description: 'A number to decrease the volume by.',
+                type: 'number',
+                required: true,
+            },
+        ],
+        handler: (args: Record<string, unknown>): number => {
+            try {
+                const speaker = audio?.defaultSpeaker;
+
+                if (speaker === undefined) {
+                    throw new Error('A default speaker was not found.');
+                }
+
+                const volumeInput = Number(args['volume']) / 100;
+
+                if (options.menus.volume.raiseMaximumVolume.get()) {
+                    speaker.set_volume(Math.min(speaker.volume - volumeInput, 1.5));
+                } else {
+                    speaker.set_volume(Math.min(speaker.volume - volumeInput, 1));
                 }
 
                 return Math.round((speaker.volume + volumeInput) * 100);


### PR DESCRIPTION
Fixed the scrolling on the volume bar (as per #1010 ) not working correctly because it was interpreting a negative value as an option instead of an argument.