### PR TITLE
Fixed css in audio menu, sort audio devices

### DIFF
--- a/src/components/menus/audio/available/PlaybackDevices.tsx
+++ b/src/components/menus/audio/available/PlaybackDevices.tsx
@@ -17,9 +17,12 @@ export const PlaybackDevices = (): JSX.Element => {
                         return <NotFoundButton type={'playback'} />;
                     }
 
-                    return devices.map((device) => {
-                        return <AudioDevice device={device} type={'playback'} icon={''} />;
-                    });
+                    return devices
+                        .slice()
+                        .sort((a, b) => a.description.localeCompare(b.description))
+                        .map((device) => {
+                            return <AudioDevice device={device} type={'playback'} icon={''} />;
+                        });
                 })}
             </box>
         </box>

--- a/src/style/scss/menus/audiomenu.scss
+++ b/src/style/scss/menus/audiomenu.scss
@@ -1,4 +1,5 @@
 .menu-items.audio {
+    background: if($bar-menus-monochrome, $bar-menus-background, $bar-menus-menu-volume-background-color);
     border-color: if($bar-menus-monochrome, $bar-menus-border-color, $bar-menus-menu-volume-border-color);
     opacity: $bar-menus-opacity * 0.01;
 }
@@ -11,8 +12,6 @@
     * {
         font-size: $font-size * $bar-menus-menu-volume-scaling * 0.01;
     }
-
-    background: if($bar-menus-monochrome, $bar-menus-background, $bar-menus-menu-volume-background-color);
 
     .menu-dropdown-label.audio {
         color: if($bar-menus-monochrome, $bar-menus-label, $bar-menus-menu-volume-label-color);


### PR DESCRIPTION
This PR fixes border in audio menu to look like other menus:
![audio_small_fix_before_after](https://github.com/user-attachments/assets/02878b7d-1655-4b71-9bcd-ac7f1dd54b25)

Also it sorts audio devices alphabetically, by default order can be different every time you boot. 
So my fix ensures that they are in the same order every time.