### PR TITLE
feat: add ability to auto dnd on screenshare

### DIFF
--- a/src/components/settings/pages/config/notifications/index.tsx
+++ b/src/components/settings/pages/config/notifications/index.tsx
@@ -81,6 +81,12 @@ export const NotificationSettings = (): JSX.Element => {
                     type="boolean"
                 />
                 <Option
+                    opt={options.notifications.dndOnScreencast}
+                    title="Do Not Disturb On Screenshare"
+                    subtitle="Automatically enables do-not-disturb when a screenshare is started and disables it when one ends."
+                    type="boolean"
+                />
+                <Option
                     opt={options.notifications.cache_actions}
                     title="Preserve Actions"
                     subtitle="Persist action buttons after reboot."

--- a/src/configuration/modules/config/notifications/index.ts
+++ b/src/configuration/modules/config/notifications/index.ts
@@ -12,4 +12,5 @@ export default {
     autoDismiss: opt(false),
     cache_actions: opt(true),
     clearDelay: opt(100),
+    dndOnScreencast: opt(false),
 };

--- a/src/core/behaviors/doNotDisturbOnScreenshare.ts
+++ b/src/core/behaviors/doNotDisturbOnScreenshare.ts
@@ -1,0 +1,50 @@
+import AstalHyprland from 'gi://AstalHyprland?version=0.1';
+import AstalNotifd from 'gi://AstalNotifd?version=0.1';
+import options from '../../configuration';
+
+const hyprlandService = AstalHyprland.get_default();
+const notifdService = AstalNotifd.get_default();
+
+export const enableDoNotDisturbOnScrenshare = (): void => {
+    let signalId: number | undefined = undefined;
+
+    const connect = (): void => {
+        disconnect();
+        signalId = hyprlandService.connect('event', (_, event, bar) => {
+            if (event !== 'screencast') {
+                return;
+            }
+
+            const [isTurnedOn] = bar.split(',');
+
+            if (isTurnedOn === '0') {
+                notifdService.set_dont_disturb(false);
+            }
+
+            if (isTurnedOn === '1') {
+                notifdService.set_dont_disturb(true);
+            }
+        });
+    };
+
+    const disconnect = (): void => {
+        if (signalId !== undefined) {
+            hyprlandService.disconnect(signalId);
+            signalId = undefined;
+        }
+    };
+
+    const enabled = options.notifications.dndOnScreencast.get();
+
+    if (enabled) {
+        connect();
+    }
+
+    options.notifications.dndOnScreencast.subscribe((value) => {
+        if (value) {
+            connect();
+        } else {
+            disconnect();
+        }
+    });
+};

--- a/src/core/behaviors/index.ts
+++ b/src/core/behaviors/index.ts
@@ -2,6 +2,7 @@ import '../../services/display/bar/autoHide';
 import { warnOnLowBattery } from './batteryWarning';
 import { hyprlandSettings } from './hyprlandRules';
 import { BarAutoHideService } from '../../services/display/bar/autoHide';
+import { enableDoNotDisturbOnScrenshare } from './doNotDisturbOnScreenshare';
 
 const autoHide = BarAutoHideService.getInstance();
 
@@ -9,4 +10,5 @@ export const initializeSystemBehaviors = (): void => {
     warnOnLowBattery();
     autoHide.initialize();
     hyprlandSettings();
+    enableDoNotDisturbOnScrenshare();
 };


### PR DESCRIPTION
This adds an option that automatically turns on do-not-disturb in the astal notifd notification daemon when a screenshare starts (see the `screencast` event on https://wiki.hypr.land/0.47.0/Plugins/Development/Event-list/) and disables it, when the screenshare stops