### PR TITLE
fix: incorrectly identifying teamspeak window label as 'teams'.

### DIFF
--- a/src/components/bar/modules/window_title/helpers/appIcons.ts
+++ b/src/components/bar/modules/window_title/helpers/appIcons.ts
@@ -61,6 +61,7 @@ export const defaultWindowTitleMap = [
     ['telegram-desktop', '', 'Telegram'],
     ['org.telegram.desktop', '', 'Telegram'],
     ['whatsapp', '󰖣', 'WhatsApp'],
+    ['teamspeak', '', 'TeamSpeak'],
     ['teams', '󰊻', 'Microsoft Teams'],
     ['skype', '󰒯', 'Skype'],
     ['thunderbird', '', 'Thunderbird'],


### PR DESCRIPTION
closes #1086