### PR TITLE
feat:Add name option to workspace bar

### DIFF
--- a/src/components/bar/modules/workspaces/helpers/index.ts
+++ b/src/components/bar/modules/workspaces/helpers/index.ts
@@ -180,7 +180,8 @@ export const getAppIcon = (
  *
  * @param showIcons A boolean indicating whether to show icons.
  * @param showNumbered A boolean indicating whether to show numbered workspaces.
- * @param numberedActiveIndicator The indicator for active numbered workspaces.
+ * @param numberedActiveIndicator The indicator for active numbered/named workspaces.
+ * @param showNames A boolean indicating whether to show workspace names.
  * @param showWsIcons A boolean indicating whether to show workspace icons.
  * @param smartHighlight A boolean indicating whether smart highlighting is enabled.
  * @param monitor The index of the monitor to check for active workspaces.
@@ -192,6 +193,7 @@ export const renderClassnames = (
     showIcons: boolean,
     showNumbered: boolean,
     numberedActiveIndicator: string,
+    showNames: boolean,
     showWsIcons: boolean,
     smartHighlight: boolean,
     monitor: number,
@@ -205,7 +207,7 @@ export const renderClassnames = (
         return `workspace-icon txt-icon bar ${isActive}`;
     }
 
-    if (showNumbered || showWsIcons) {
+    if (showNumbered || showWsIcons || showNames) {
         const numActiveInd = isWorkspaceActive ? numberedActiveIndicator : '';
 
         const wsIconClass = showWsIcons ? 'txt-icon' : '';
@@ -237,6 +239,9 @@ export const renderClassnames = (
  * @param i The index of the workspace for which to render the label.
  * @param index The index of the workspace in the list.
  * @param monitor The index of the monitor to check for active workspaces.
+ * @param showNumbered A boolean indicating whether to show numbers.
+ * @param showNames A boolean indicating whether to show names.
+ * @param The workspace name.
  *
  * @returns The label for the workspace as a string.
  */
@@ -253,6 +258,9 @@ export const renderLabel = (
     i: number,
     index: number,
     monitor: number,
+    showNumbered: boolean,
+    showNames: boolean,
+    wsName: string,
 ): string => {
     if (showAppIcons) {
         return appIcons;
@@ -272,6 +280,25 @@ export const renderLabel = (
 
     if (showWorkspaceIcons) {
         return getWsIcon(wsIconMap, i);
+    }
+
+    if (showNames && !showNumbered) {
+        if (workspaceMask) {
+            if (workspaceMask && wsName == i.toString()) {
+                return `${index + 1}`;
+            }
+        }
+        return wsName;
+    }
+
+    if (showNames && showNumbered) {
+        // this is to avoid writing the number twice for unnamed workspaces, or output a second number with mask
+        // compare to i because unnamed workspace take their id as name
+        if (workspaceMask) {
+            return wsName == i.toString() ? `${index + 1}` : `${index + 1} ${wsName}`;
+        }
+
+        return wsName == i.toString() ? `${i}` : `${i} ${wsName}`;
     }
 
     return workspaceMask ? `${index + 1}` : `${i}`;

--- a/src/components/bar/modules/workspaces/workspaces.tsx
+++ b/src/components/bar/modules/workspaces/workspaces.tsx
@@ -21,6 +21,7 @@ const {
     show_icons,
     show_numbered,
     numbered_active_indicator,
+    show_names,
     workspaceIconMap,
     showWsIcons,
     showApplicationIcons,
@@ -48,6 +49,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             bind(occupied),
             bind(show_numbered),
             bind(numbered_active_indicator),
+            bind(show_names),
             bind(spacing),
             bind(workspaceIconMap),
             bind(showWsIcons),
@@ -78,6 +80,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             occupiedStatus: string,
             displayNumbered: boolean,
             numberedActiveIndicator: string,
+            displayName: boolean,
             spacingValue: number,
             workspaceIconMapping: WorkspaceIconMap,
             displayWorkspaceIcons: boolean,
@@ -109,6 +112,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                           emptyIcon: applicationIconEmptyWorkspace,
                       })
                     : '';
+                const wsName = hyprlandService.get_workspace(wsId).get_name();
 
                 return (
                     <button
@@ -129,6 +133,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                                 displayIcons,
                                 displayNumbered,
                                 numberedActiveIndicator,
+                                displayName,
                                 displayWorkspaceIcons,
                                 smartHighlightEnabled,
                                 monitor,
@@ -147,6 +152,9 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                                 wsId,
                                 index,
                                 monitor,
+                                displayNumbered,
+                                displayName,
+                                wsName,
                             )}
                             setup={(self) => {
                                 const currentWsClients = clients.filter(

--- a/src/components/settings/pages/config/bar/index.tsx
+++ b/src/components/settings/pages/config/bar/index.tsx
@@ -201,6 +201,12 @@ export const BarSettings = (): JSX.Element => {
                     type="boolean"
                 />
                 <Option
+                    opt={options.bar.workspaces.show_names}
+                    title="Show Workspace Names"
+                    subtitle="Set in hyprland config."
+                    type="boolean"
+                />
+                <Option
                     opt={options.bar.workspaces.showWsIcons}
                     title="Map Workspaces to Icons"
                     subtitle="https://hyprpanel.com/configuration/panel.html#show-workspace-icons"
@@ -225,8 +231,8 @@ export const BarSettings = (): JSX.Element => {
                 />
                 <Option
                     opt={options.bar.workspaces.numbered_active_indicator}
-                    title="Numbered Workspace Identifier"
-                    subtitle="Only applicable if Workspace Numbers are enabled"
+                    title="Numbered/Names Workspace Identifier"
+                    subtitle="Only applicable if Workspace Numbers or Names are enabled."
                     type="enum"
                     enums={['underline', 'highlight', 'color']}
                 />

--- a/src/components/settings/side_effects/index.ts
+++ b/src/components/settings/side_effects/index.ts
@@ -1,7 +1,7 @@
 import { Opt } from 'src/lib/options';
 import options from 'src/configuration';
 
-const { show_numbered, show_icons, showWsIcons, showApplicationIcons } = options.bar.workspaces;
+const { show_numbered, show_icons, showWsIcons, showApplicationIcons, show_names } = options.bar.workspaces;
 const { monochrome: monoBar } = options.theme.bar.buttons;
 const { monochrome: monoMenu } = options.theme.bar.menus;
 const { matugen } = options.theme;
@@ -37,10 +37,10 @@ const turnOffOptionVars = (
 /* ================================================== */
 /*               WORKSPACE SIDE EFFECTS               */
 /* ================================================== */
-const workspaceOptsToDisable = [show_numbered, show_icons, showWsIcons, showApplicationIcons];
+const workspaceOptsToDisable = [show_numbered, show_icons, showWsIcons, showApplicationIcons, show_names];
 
 show_numbered.subscribe(() => {
-    turnOffOptionVars(show_numbered, workspaceOptsToDisable);
+    turnOffOptionVars(show_numbered, workspaceOptsToDisable, [show_names]);
 });
 
 show_icons.subscribe(() => {
@@ -57,6 +57,10 @@ showApplicationIcons.subscribe(() => {
     if (showApplicationIcons.get()) {
         showWsIcons.set(true);
     }
+});
+
+show_names.subscribe(() => {
+    turnOffOptionVars(show_names, workspaceOptsToDisable, [show_numbered]);
 });
 
 /* ================================================== */

--- a/src/configuration/modules/config/bar/workspaces/index.ts
+++ b/src/configuration/modules/config/bar/workspaces/index.ts
@@ -11,6 +11,7 @@ export default {
     showAllActive: opt(true),
     ignored: opt(''),
     show_numbered: opt(false),
+    show_names: opt(false),
     showWsIcons: opt(false),
     showApplicationIcons: opt(false),
     applicationIconOncePerWorkspace: opt(true),


### PR DESCRIPTION
This PR addresses #358

I've always liked to have named workspaces displaying for organisation. Additionally I like to have the number for ease of navigation. This implements both of them.

I have used the same style option as numbered, due to it also being a string display. Having both name and number with different style was not feasible. 

**Examples**

Monitor specific with both:
<img width="335" height="42" alt="image" src="https://github.com/user-attachments/assets/ece8d42e-67c4-4d0f-a69c-75bd7fadfe37" />
<img width="579" height="40" alt="image" src="https://github.com/user-attachments/assets/0734c226-6e51-492c-9142-b7f22704514a" />

Just names, with the number displayed if unnamed:
<img width="487" height="40" alt="image" src="https://github.com/user-attachments/assets/8f6d83d5-e8c6-41c3-8ce3-e5ca3c12b30e" />

Zero based with correct number if unnamed:
<img width="285" height="45" alt="image" src="https://github.com/user-attachments/assets/5807379c-0b7b-4060-ba83-04c9f2ba0ab3" />
