### PR TITLE
Remove unwanted modules from HyprPanel

### DIFF
--- a/src/components/bar/layout/coreWidgets.tsx
+++ b/src/components/bar/layout/coreWidgets.tsx
@@ -1,5 +1,3 @@
-import { BatteryLabel } from '../modules/battery';
-import { Bluetooth } from '../modules/bluetooth';
 import { Cava } from '../modules/cava';
 import { Clock } from '../modules/clock';
 import { Cpu } from '../modules/cpu';
@@ -7,40 +5,26 @@ import { CpuTemp } from '../modules/cputemp';
 import { Hypridle } from '../modules/hypridle';
 import { Hyprsunset } from '../modules/hyprsunset';
 import { KbInput } from '../modules/kblayout';
-import { Media } from '../modules/media';
 import { Menu } from '../modules/menu';
 import { Microphone } from '../modules/microphone';
 import { Netstat } from '../modules/netstat';
-import { Network } from '../modules/network';
-import { Notifications } from '../modules/notifications';
 import { Power } from '../modules/power';
 import { Ram } from '../modules/ram';
 import { ModuleSeparator } from '../modules/separator';
 import { Storage } from '../modules/storage';
 import { Submap } from '../modules/submap';
-import { SysTray } from '../modules/systray';
 import { Updates } from '../modules/updates';
 import { Volume } from '../modules/volume';
 import { Weather } from '../modules/weather';
-import { ClientTitle } from '../modules/window_title';
-import { Workspaces } from '../modules/workspaces';
 import { WorldClock } from '../modules/worldclock';
 import { WidgetContainer } from '../shared/widgetContainer';
 import { WidgetFactory } from './WidgetRegistry';
 
 export function getCoreWidgets(): Record<string, WidgetFactory> {
     return {
-        battery: () => WidgetContainer(BatteryLabel()),
         dashboard: () => WidgetContainer(Menu()),
-        workspaces: (monitor: number) => WidgetContainer(Workspaces(monitor)),
-        windowtitle: () => WidgetContainer(ClientTitle()),
-        media: () => WidgetContainer(Media()),
-        notifications: () => WidgetContainer(Notifications()),
         volume: () => WidgetContainer(Volume()),
-        network: () => WidgetContainer(Network()),
-        bluetooth: () => WidgetContainer(Bluetooth()),
         clock: () => WidgetContainer(Clock()),
-        systray: () => WidgetContainer(SysTray()),
         microphone: () => WidgetContainer(Microphone()),
         ram: () => WidgetContainer(Ram()),
         cpu: () => WidgetContainer(Cpu()),

--- a/src/configuration/modules/config/bar/index.ts
+++ b/src/configuration/modules/config/bar/index.ts
@@ -1,7 +1,5 @@
 import { opt } from 'src/lib/options';
 import { AutoHide } from 'src/lib/options/types';
-import battery from './battery';
-import bluetooth from './bluetooth';
 import cava from './cava';
 import clock from './clock';
 import cpu from './cpu';
@@ -11,21 +9,15 @@ import hyprsunset from './hyprsunset';
 import kbLayout from './kbLayout';
 import launcher from './launcher';
 import layouts from './layouts';
-import media from './media';
 import microphone from './microphone';
 import netstat from './netstat';
-import network from './network';
-import notifications from './notifications';
 import power from './power';
 import ram from './ram';
 import storage from './storage';
 import submap from './submap';
-import systray from './systray';
 import updates from './updates';
 import volume from './volume';
 import weather from './weather';
-import windowtitle from './windowtitle';
-import workspaces from './workspaces';
 import worldclock from './worldclock';
 
 export default {
@@ -33,16 +25,8 @@ export default {
     autoHide: opt<AutoHide>('never'),
     layouts,
     launcher,
-    windowtitle,
-    workspaces,
     volume,
-    network,
-    bluetooth,
-    battery,
-    systray,
     clock,
-    media,
-    notifications,
     customModules: {
         scrollSpeed: opt(5),
         microphone,

--- a/src/configuration/modules/config/bar/layouts/index.ts
+++ b/src/configuration/modules/config/bar/layouts/index.ts
@@ -3,18 +3,18 @@ import { BarLayouts } from 'src/lib/options/types';
 
 export default opt<BarLayouts>({
     '1': {
-        left: ['dashboard', 'workspaces', 'windowtitle'],
-        middle: ['media'],
-        right: ['volume', 'clock', 'notifications'],
+        left: ['dashboard'],
+        middle: [],
+        right: ['volume', 'clock'],
     },
     '2': {
-        left: ['dashboard', 'workspaces', 'windowtitle'],
-        middle: ['media'],
-        right: ['volume', 'clock', 'notifications'],
+        left: ['dashboard'],
+        middle: [],
+        right: ['volume', 'clock'],
     },
     '0': {
-        left: ['dashboard', 'workspaces', 'windowtitle'],
-        middle: ['media'],
-        right: ['volume', 'network', 'bluetooth', 'battery', 'systray', 'clock', 'notifications'],
+        left: ['dashboard'],
+        middle: [],
+        right: ['volume', 'clock'],
     },
 });

--- a/src/lib/options/types.ts
+++ b/src/lib/options/types.ts
@@ -17,15 +17,8 @@ export type OptionsObject = Record<string, unknown>;
 export type BarLocation = 'top' | 'bottom';
 export type AutoHide = 'never' | 'fullscreen' | 'single-window';
 export type BarModule =
-    | 'battery'
     | 'dashboard'
-    | 'workspaces'
-    | 'windowtitle'
-    | 'media'
-    | 'notifications'
     | 'volume'
-    | 'network'
-    | 'bluetooth'
     | 'clock'
     | 'ram'
     | 'cpu'
@@ -37,7 +30,6 @@ export type BarModule =
     | 'submap'
     | 'weather'
     | 'power'
-    | 'systray'
     | 'hypridle'
     | 'hyprsunset'
     | 'cava';


### PR DESCRIPTION
- Remove Workspaces, Network, Battery, Bluetooth, System Tray, Notifications, Media, and Window Titles modules
- Update core widgets registry to exclude removed modules
- Update BarModule type definition to remove module types
- Update bar configuration to remove module imports and exports
- Update layout configurations to remove modules from all monitor layouts
- Keep all other modules and functionality intact