### PR TITLE
A couple null checks

### DIFF
--- a/src/components/bar/utils/monitors/index.ts
+++ b/src/components/bar/utils/monitors/index.ts
@@ -66,7 +66,19 @@ export const getLayoutForMonitor = (monitor: number, layouts: BarLayouts): BarLa
 
 const _getResolveLayoutForMonitor = (monitor: number, layouts: BarLayouts): [string, BarLayout] => {
     const hyprlandService = AstalHyprland.get_default();
-    const monitorConn = hyprlandService.get_monitor(monitor).get_name();
+    const mon = hyprlandService.get_monitor(monitor);
+    if (mon == undefined) {
+      return [
+          'default',
+          {
+              left: ['dashboard', 'workspaces', 'windowtitle'],
+              middle: ['media'],
+              right: ['volume', 'network', 'bluetooth', 'battery', 'systray', 'clock', 'notifications'],
+          },
+      ];
+    }
+
+    const monitorConn = mon.get_name();
 
     const matchingConn = Object.keys(layouts).find((key) => key === monitorConn);
     if (matchingConn !== undefined) {

--- a/src/components/notifications/index.tsx
+++ b/src/components/notifications/index.tsx
@@ -28,7 +28,7 @@ export default (): JSX.Element => {
     const windowMonitor = Variable.derive(
         [bind(hyprlandService, 'focusedMonitor'), bind(monitor), bind(active_monitor)],
         (focusedMonitor, monitor, activeMonitor) => {
-            if (activeMonitor === true) {
+            if ((activeMonitor === true) && (focusedMonitor != undefined)) {
                 const gdkMonitor = gdkMonitorMapper.mapHyprlandToGdk(focusedMonitor.id);
                 return gdkMonitor;
             }


### PR DESCRIPTION
I have a KVM so that I can switch my monitor/keyboard/mouse setup between my desktop and laptop.  When I switch, hyprpanel gets an error.  The process doesn't die, but the panel no longer shows.  I get this error:

```
(gjs:3693613): hyprpanel-CRITICAL **: 08:05:10.569: [MonitorRefresh] Error during component refresh: TypeError: focusedMonitor is null
notifications_default5/windowMonitor<@file:///run/user/1000/dmFyIF-ags.js:24134:63
update@file:///run/user/1000/dmFyIF-ags.js:313:32
derive@file:///run/user/1000/dmFyIF-ags.js:314:38
notifications_default5@file:///run/user/1000/dmFyIF-ags.js:24130:34
_refreshMonitors@file:///run/user/1000/dmFyIF-ags.js:29852:7
async*handleMonitorChange/this._monitorChangeTimeout<@file:///run/user/1000/dmFyIF-ags.js:29829:12
setTimeout/source<@resource:///org/gnome/gjs/modules/esm/_timers.js:72:9
_init/GLib.MainLoop.prototype.runAsync/</<@resource:///org/gnome/gjs/modules/core/overrides/GLib.js:263:34
```

This PR introduces 2 simple null checks to keep this from happening.  Tested locally and works, but still outputs some warnings.