### PR TITLE
Workspace seperate active focused

### DIFF
--- a/src/components/bar/modules/workspaces/helpers/index.ts
+++ b/src/components/bar/modules/workspaces/helpers/index.ts
@@ -197,26 +197,28 @@ export const renderClassnames = (
     monitor: number,
     i: number,
 ): string => {
-    const isWorkspaceActive =
-        hyprlandService.focusedWorkspace?.id === i || isWorkspaceActiveOnMonitor(monitor, i);
-    const isActive = isWorkspaceActive ? 'active' : '';
+    const isActive = isWorkspaceActiveOnMonitor(monitor, i);
+    const isActiveClass = isActive ? 'active' : 'inactive';
+    const isFocused = hyprlandService.focusedWorkspace?.id === i;
+    const isFocusedClass = isFocused ? 'focused' : '';
+    const activeOnAnyWs = isWorkspaceActiveOnAnyMonitor(i);
+    const activeOnAnyWsClass = activeOnAnyWs ? 'active-on-any' : '';
 
     if (showIcons) {
-        return `workspace-icon txt-icon bar ${isActive}`;
+        return `workspace-icon txt-icon bar ${isActiveClass}`;
     }
 
     if (showNumbered || showWsIcons) {
-        const numActiveInd = isWorkspaceActive ? numberedActiveIndicator : '';
+        const numActiveInd = isActive ? numberedActiveIndicator : '';
 
         const wsIconClass = showWsIcons ? 'txt-icon' : '';
         const smartHighlightClass = smartHighlight ? 'smart-highlight' : '';
-
-        const className = `workspace-number can_${numberedActiveIndicator} ${numActiveInd} ${wsIconClass} ${smartHighlightClass} ${isActive}`;
+        const className = `workspace-number can_${numberedActiveIndicator} ${numActiveInd} ${wsIconClass} ${smartHighlightClass} ${isActiveClass} ${isFocusedClass} ${activeOnAnyWsClass}`;
 
         return className.trim();
     }
 
-    return `default ${isActive}`;
+    return `default ${isActiveClass}`;
 };
 
 /**

--- a/src/components/bar/modules/workspaces/helpers/index.ts
+++ b/src/components/bar/modules/workspaces/helpers/index.ts
@@ -28,6 +28,20 @@ const isWorkspaceActiveOnMonitor = (monitor: number, i: number): boolean => {
 };
 
 /**
+ * Determines if a workspace is active on any monitor.
+ *
+ * This function checks if the workspace with the specified index is currently active on any monitor.
+ * It uses the `hyprlandService` to iterate through all monitors and check their active workspaces.
+ *
+ * @param i The index of the workspace to check.
+ * @returns True if the workspace is active on any monitor, false otherwise.
+ */
+
+const isWorkspaceActiveOnAnyMonitor = (i: number): boolean => {
+    return hyprlandService.get_monitors().some((monitor) => monitor?.activeWorkspace?.id === i);
+};
+
+/**
  * Retrieves the icon for a given workspace.
  *
  * This function returns the icon associated with a workspace from the provided workspace icon map.
@@ -69,6 +83,7 @@ const getWsIcon = (wsIconMap: WorkspaceIconMap, i: number): string => {
  * @param i The index of the workspace for which to retrieve the color.
  * @param smartHighlight A boolean indicating whether smart highlighting is enabled.
  * @param monitor The index of the monitor to check for active workspaces.
+ * @param highlightKind Which kind of workspaces to highlight: 'active', 'focused', or 'both'.
  *
  * @returns A CSS string representing the color and background for the workspace. If no color is found, returns an empty string.
  */
@@ -77,6 +92,7 @@ export const getWsColor = (
     i: number,
     smartHighlight: boolean,
     monitor: number,
+    highlightKind: string,
 ): string => {
     const iconEntry = wsIconMap[i];
     const hasColor =
@@ -90,7 +106,7 @@ export const getWsColor = (
         showWsIcons.get() &&
         smartHighlight &&
         wsActiveIndicator.get() === 'highlight' &&
-        (hyprlandService.focusedWorkspace?.id === i || isWorkspaceActiveOnMonitor(monitor, i))
+        getHighlightWs(highlightKind, monitor, i)
     ) {
         const iconColor = monochrome.get() ? background.get() : wsBackground.get();
         const iconBackground = hasColor && isValidGjsColor(iconEntry.color) ? iconEntry.color : active.get();
@@ -170,6 +186,29 @@ export const getAppIcon = (
     }
 
     return defaultIcon;
+};
+
+/**
+ * Determines if a workspace is active based on the highlight kind.
+ *
+ * This function checks if the workspace with the specified index is considered active based on the
+ * provided highlight kind ('active', 'focused', or 'both'). It uses the `hyprlandService` to determine
+ * the focused workspace and whether the workspace is active on the given monitor.
+ *
+ * @param highlightKind Which kind of workspaces to highlight: 'active', 'focused', or 'both'.
+ * @param monitor The index of the monitor to check for active workspaces.
+ * @param i The index of the workspace for which to check activity.
+ *
+ * @returns True if the workspace is considered active based on the highlight kind, false otherwise.
+ */
+export const getHighlightWs = (highlightKind: string, monitor: number, i: number): boolean => {
+    const isWorkspaceFocused = hyprlandService.focusedWorkspace?.id === i;
+    const isWorkspaceActive = isWorkspaceActiveOnMonitor(monitor, i);
+    return (
+        (highlightKind == 'both' && (isWorkspaceActive || isWorkspaceFocused)) ||
+        (highlightKind == 'active' && isWorkspaceActive) ||
+        (highlightKind == 'focused' && isWorkspaceFocused)
+    );
 };
 
 /**

--- a/src/components/bar/modules/workspaces/workspaces.tsx
+++ b/src/components/bar/modules/workspaces/workspaces.tsx
@@ -21,6 +21,7 @@ const {
     show_icons,
     show_numbered,
     numbered_active_indicator,
+    activeIndicatorKind,
     workspaceIconMap,
     showWsIcons,
     showApplicationIcons,
@@ -48,6 +49,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             bind(occupied),
             bind(show_numbered),
             bind(numbered_active_indicator),
+            bind(activeIndicatorKind),
             bind(spacing),
             bind(workspaceIconMap),
             bind(showWsIcons),
@@ -78,6 +80,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             occupiedStatus: string,
             displayNumbered: boolean,
             numberedActiveIndicator: string,
+            activeIndicatorKind: string,
             spacingValue: number,
             workspaceIconMapping: WorkspaceIconMap,
             displayWorkspaceIcons: boolean,
@@ -123,7 +126,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                             valign={Gtk.Align.CENTER}
                             css={
                                 `margin: 0rem ${0.375 * spacingValue}rem;` +
-                                `${displayWorkspaceIcons && !matugenEnabled ? getWsColor(workspaceIconMapping, wsId, smartHighlightEnabled, monitor) : ''}`
+                                `${displayWorkspaceIcons && !matugenEnabled ? getWsColor(workspaceIconMapping, wsId, smartHighlightEnabled, monitor, activeIndicatorKind) : ''}`
                             }
                             className={renderClassnames(
                                 displayIcons,

--- a/src/components/settings/pages/config/bar/index.tsx
+++ b/src/components/settings/pages/config/bar/index.tsx
@@ -231,6 +231,13 @@ export const BarSettings = (): JSX.Element => {
                     enums={['underline', 'highlight', 'color']}
                 />
                 <Option
+                    opt={options.bar.workspaces.activeIndicatorKind}
+                    title="Active Workspace Highlight Kind"
+                    subtitle="For multi-monitor setups, determines weather to highlight active and/or focused workspaces"
+                    type="enum"
+                    enums={['active', 'focused', 'both']}
+                />
+                <Option
                     opt={options.theme.bar.buttons.workspaces.smartHighlight}
                     title="Smart Highlight"
                     subtitle="Automatically determines highlight color for mapped icons."

--- a/src/configuration/modules/config/bar/workspaces/index.ts
+++ b/src/configuration/modules/config/bar/workspaces/index.ts
@@ -4,7 +4,7 @@ import {
     WorkspaceIconsColored,
 } from 'src/components/bar/modules/workspaces/types';
 import { opt } from 'src/lib/options';
-import { ActiveWsIndicator } from 'src/lib/options/types';
+import { ActiveWsHighlightKind, ActiveWsIndicator } from 'src/lib/options/types';
 
 export default {
     show_icons: opt(false),
@@ -18,6 +18,7 @@ export default {
     applicationIconFallback: opt('󰣆'),
     applicationIconEmptyWorkspace: opt(''),
     numbered_active_indicator: opt<ActiveWsIndicator>('underline'),
+    activeIndicatorKind: opt<ActiveWsHighlightKind>('both'),
     icons: {
         available: opt(''),
         active: opt(''),

--- a/src/lib/options/types.ts
+++ b/src/lib/options/types.ts
@@ -117,6 +117,8 @@ export type WindowLayer = 'top' | 'bottom' | 'overlay' | 'background';
 
 export type ActiveWsIndicator = 'underline' | 'highlight' | 'color';
 
+export type ActiveWsHighlightKind = 'active' | 'focused' | 'both';
+
 export type MatugenColors = {
     background: HexColor;
     error: HexColor;


### PR DESCRIPTION
Fixes #1105

This PR splits the active and focused classes for the WS label, which allowed dedicated theming but may break existing themes around this (not sure). It also adds the `acitve-on-any` CSS class to allow theming like:

```scss
label.workspace-number.active-on-any:not(.active) {
  background-color: #44475a;
}
```


It also adds a selector/setting to switch highlighting WS to either 'active', 'focused' or (default) 'both'


My first contribution to this project (or any TS project) 