### PR TITLE
feat: improve tooltips for CPU and RAM modules

### DIFF
--- a/src/components/bar/modules/cpu/index.tsx
+++ b/src/components/bar/modules/cpu/index.tsx
@@ -8,8 +8,18 @@ import CpuUsageService from 'src/services/system/cpuUsage';
 
 const inputHandler = InputHandlerService.getInstance();
 
-const { label, round, showPerCoreUsage, leftClick, rightClick, middleClick, scrollUp, scrollDown, pollingInterval, icon } =
-    options.bar.customModules.cpu;
+const {
+    label,
+    round,
+    showPerCoreUsage,
+    leftClick,
+    rightClick,
+    middleClick,
+    scrollUp,
+    scrollDown,
+    pollingInterval,
+    icon,
+} = options.bar.customModules.cpu;
 
 const cpuService = new CpuUsageService({ frequency: pollingInterval });
 
@@ -30,15 +40,17 @@ export const Cpu = (): BarBoxChild => {
                 const displayUsage = round ? Math.round(cpuUsg) : cpuUsg.toFixed(2);
                 return `CPU: ${displayUsage}%`;
             }
-            
+
             if (perCoreUsage.length === 0) return 'CPU';
-            
-            const coreLines = perCoreUsage.map((usage, index) => {
-                const displayUsage = round ? Math.round(usage) : usage.toFixed(2);
-                return `Core ${index}: ${displayUsage}%`;
-            }).join('\n');
-            
-            return `${coreLines}`;
+
+            const coreLines = perCoreUsage
+                .map((usage, index) => {
+                    const displayUsage = round ? Math.round(usage) : usage.toFixed(2);
+                    return `Core ${index}: ${displayUsage}%`;
+                })
+                .join('\n');
+
+            return coreLines;
         },
     );
 

--- a/src/components/bar/modules/ram/index.tsx
+++ b/src/components/bar/modules/ram/index.tsx
@@ -29,12 +29,19 @@ export const Ram = (): BarBoxChild => {
 
     let inputHandlerBindings: Variable<void>;
 
+    const tooltipBinding = Variable.derive(
+        [bind(ramService.ram), bind(round)],
+        (rmUsg: GenericResourceData, round: boolean) => {
+            const usedLabel = renderResourceLabel('used', rmUsg, round);
+            const totalLabel = renderResourceLabel('used', { ...rmUsg, used: rmUsg.total }, round);
+            return `RAM: ${usedLabel} / ${totalLabel}`;
+        },
+    );
+
     const ramModule = Module({
         textIcon: bind(icon),
         label: labelBinding(),
-        tooltipText: bind(labelType).as((lblTyp) => {
-            return formatTooltip('RAM', lblTyp);
-        }),
+        tooltipText: tooltipBinding(),
         boxClass: 'ram',
         showLabelBinding: bind(label),
         props: {
@@ -73,6 +80,7 @@ export const Ram = (): BarBoxChild => {
             onDestroy: () => {
                 inputHandlerBindings.drop();
                 labelBinding.drop();
+                tooltipBinding.drop();
                 ramService.destroy();
             },
         },

--- a/src/components/bar/modules/ram/index.tsx
+++ b/src/components/bar/modules/ram/index.tsx
@@ -3,7 +3,7 @@ import { bind, Variable } from 'astal';
 import { Astal } from 'astal/gtk3';
 import { BarBoxChild } from 'src/components/bar/types';
 import options from 'src/configuration';
-import { renderResourceLabel, formatTooltip } from '../../utils/systemResource';
+import { renderResourceLabel } from '../../utils/systemResource';
 import { InputHandlerService } from '../../utils/input/inputHandler';
 import { GenericResourceData, ResourceLabelType, LABEL_TYPES } from 'src/services/system/types';
 import RamUsageService from 'src/services/system/ramUsage';

--- a/src/components/bar/settings/config.tsx
+++ b/src/components/bar/settings/config.tsx
@@ -101,6 +101,7 @@ export const CustomModuleSettings = (): JSX.Element => {
                 <Option opt={options.bar.customModules.cpu.label} title="Show Label" type="boolean" />
                 <Option opt={options.theme.bar.buttons.modules.cpu.spacing} title="Spacing" type="string" />
                 <Option opt={options.bar.customModules.cpu.round} title="Round" type="boolean" />
+                <Option opt={options.bar.customModules.cpu.showPerCoreUsage} title="Show Tooltip Per-Core Usage" type="boolean" />
                 <Option
                     opt={options.bar.customModules.cpu.pollingInterval}
                     title="Polling Interval"

--- a/src/components/bar/settings/config.tsx
+++ b/src/components/bar/settings/config.tsx
@@ -101,7 +101,11 @@ export const CustomModuleSettings = (): JSX.Element => {
                 <Option opt={options.bar.customModules.cpu.label} title="Show Label" type="boolean" />
                 <Option opt={options.theme.bar.buttons.modules.cpu.spacing} title="Spacing" type="string" />
                 <Option opt={options.bar.customModules.cpu.round} title="Round" type="boolean" />
-                <Option opt={options.bar.customModules.cpu.showPerCoreUsage} title="Show Tooltip Per-Core Usage" type="boolean" />
+                <Option
+                    opt={options.bar.customModules.cpu.showPerCoreUsage}
+                    title="Show Tooltip Per-Core Usage"
+                    type="boolean"
+                />
                 <Option
                     opt={options.bar.customModules.cpu.pollingInterval}
                     title="Polling Interval"

--- a/src/components/bar/utils/systemResource/index.ts
+++ b/src/components/bar/utils/systemResource/index.ts
@@ -64,7 +64,8 @@ export const renderResourceLabel = (
         return SizeConverter.fromBytes(free).formatAuto(precision);
     }
 
-    return `${percentage}%`;
+    const roundedPercentage = round ? Math.round(percentage) : percentage.toFixed(2);
+    return `${roundedPercentage}%`;
 };
 
 /**

--- a/src/configuration/modules/config/bar/cpu/index.ts
+++ b/src/configuration/modules/config/bar/cpu/index.ts
@@ -1,9 +1,10 @@
 import { opt } from 'src/lib/options';
 
 export default {
-    icon: opt(''),
+    icon: opt(''),
     label: opt(true),
     round: opt(true),
+    showPerCoreUsage: opt(true),
     pollingInterval: opt(2000),
     leftClick: opt(''),
     rightClick: opt(''),

--- a/src/services/system/cpuUsage/index.ts
+++ b/src/services/system/cpuUsage/index.ts
@@ -114,7 +114,7 @@ class CpuUsageService {
         const cpuUsagePercentage = totalDiff > 0 ? ((totalDiff - inactiveTime) / totalDiff) * 100 : 0;
 
         this._calculatePerCoreUsage();
-        
+
         this._previousCpuData = currentCpuData;
 
         return cpuUsagePercentage;

--- a/src/services/system/cpuUsage/index.ts
+++ b/src/services/system/cpuUsage/index.ts
@@ -1,7 +1,12 @@
-import { bind, Variable } from 'astal';
+import { bind, GLib, Variable } from 'astal';
 import GTop from 'gi://GTop';
 import { FunctionPoller } from 'src/lib/poller/FunctionPoller';
 import { CpuServiceCtor } from './types';
+
+interface CoreStat {
+    total: number;
+    idle: number;
+}
 
 /**
  * Service for monitoring CPU usage percentage
@@ -11,12 +16,16 @@ class CpuUsageService {
     private _previousCpuData = new GTop.glibtop_cpu();
     private _cpuPoller: FunctionPoller<number, []>;
     private _isInitialized = false;
+    private _previousPerCoreData: CoreStat[] = [];
 
     private _cpu = Variable(0);
+    private _perCoreUsage = Variable<number[]>([]);
 
     constructor({ frequency }: CpuServiceCtor = {}) {
         this._updateFrequency = frequency ?? Variable(2000);
         GTop.glibtop_get_cpu(this._previousCpuData);
+
+        this._initializePerCoreData();
 
         this._calculateUsage = this._calculateUsage.bind(this);
 
@@ -26,6 +35,41 @@ class CpuUsageService {
             bind(this._updateFrequency),
             this._calculateUsage,
         );
+    }
+
+    /**
+     * Initializes per-core CPU data from /proc/stat
+     */
+    private _initializePerCoreData(): void {
+        try {
+            const [success, statBytes] = GLib.file_get_contents('/proc/stat');
+            if (!success || !statBytes) return;
+
+            const statContent = new TextDecoder('utf-8').decode(statBytes);
+            const lines = statContent.split('\n');
+
+            this._previousPerCoreData = [];
+
+            for (const line of lines) {
+                if (/^cpu\d+/.test(line)) {
+                    const parts = line.trim().split(/\s+/);
+                    if (parts.length >= 5) {
+                        const user = parseInt(parts[1], 10) || 0;
+                        const nice = parseInt(parts[2], 10) || 0;
+                        const system = parseInt(parts[3], 10) || 0;
+                        const idle = parseInt(parts[4], 10) || 0;
+                        const iowait = parseInt(parts[5] || '0', 10) || 0;
+
+                        const total = user + nice + system + idle + iowait;
+                        this._previousPerCoreData.push({ total, idle });
+                    } else {
+                        this._previousPerCoreData.push({ total: 0, idle: 0 });
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('Error initializing per-core CPU data:', error);
+        }
     }
 
     /**
@@ -45,6 +89,15 @@ class CpuUsageService {
     }
 
     /**
+     * Gets the per-core CPU usage percentages
+     *
+     * @returns Variable containing array of CPU usage percentages for each core
+     */
+    public get perCoreUsage(): Variable<number[]> {
+        return this._perCoreUsage;
+    }
+
+    /**
      * Calculates the current CPU usage percentage based on CPU time deltas
      *
      * @returns Current CPU usage percentage
@@ -60,9 +113,60 @@ class CpuUsageService {
         const inactiveTime = idleDiff + iowaitDiff;
         const cpuUsagePercentage = totalDiff > 0 ? ((totalDiff - inactiveTime) / totalDiff) * 100 : 0;
 
+        this._calculatePerCoreUsage();
+        
         this._previousCpuData = currentCpuData;
 
         return cpuUsagePercentage;
+    }
+
+    /**
+     * Calculates per-core CPU usage from /proc/stat
+     */
+    private _calculatePerCoreUsage(): void {
+        try {
+            const [success, statBytes] = GLib.file_get_contents('/proc/stat');
+            if (!success || !statBytes) return;
+
+            const statContent = new TextDecoder('utf-8').decode(statBytes);
+            const lines = statContent.split('\n');
+            const perCoreUsages: number[] = [];
+            let coreIndex = 0;
+
+            for (const line of lines) {
+                if (/^cpu\d+/.test(line)) {
+                    const parts = line.trim().split(/\s+/);
+                    if (parts.length >= 5 && coreIndex < this._previousPerCoreData.length) {
+                        const user = parseInt(parts[1], 10) || 0;
+                        const nice = parseInt(parts[2], 10) || 0;
+                        const system = parseInt(parts[3], 10) || 0;
+                        const idle = parseInt(parts[4], 10) || 0;
+                        const iowait = parseInt(parts[5] || '0', 10) || 0;
+
+                        const currentTotal = user + nice + system + idle + iowait;
+                        const currentIdle = idle;
+
+                        const prevData = this._previousPerCoreData[coreIndex];
+                        const totalDiff = currentTotal - prevData.total;
+                        const idleDiff = currentIdle - prevData.idle;
+
+                        const coreUsage = totalDiff > 0 ? ((totalDiff - idleDiff) / totalDiff) * 100 : 0;
+                        perCoreUsages.push(parseFloat(coreUsage.toFixed(2)));
+
+                        this._previousPerCoreData[coreIndex] = { total: currentTotal, idle: currentIdle };
+                    } else {
+                        perCoreUsages.push(0);
+                    }
+                    coreIndex++;
+                }
+            }
+
+            if (perCoreUsages.length > 0) {
+                this._perCoreUsage.set(perCoreUsages);
+            }
+        } catch (error) {
+            console.error('Error calculating per-core CPU usage:', error);
+        }
     }
 
     /**
@@ -104,6 +208,7 @@ class CpuUsageService {
     public destroy(): void {
         this._cpuPoller.stop();
         this._cpu.drop();
+        this._perCoreUsage.drop();
         this._updateFrequency.drop();
     }
 }


### PR DESCRIPTION
This PR improve the CPU usage monitoring module to the bar with per-core usage display and the RAM usage with used/max tooltip

### Features Added

#### 1. **CPU Usage Module**
- Added new CPU monitoring per core option for the tooltip
- Added `showPerCoreUsage` configuration option
  When enabled, hovering over the module shows:
  - Individual usage percentage for each CPU core using stats from `/proc/stat`
  - Core numbering for easy identification
  - When disabled, shows simple overall CPU usage in tooltip
  - Respects the same rounding setting as the main display

<img width="257" height="87" alt="screenshot_20251128_110412" src="https://github.com/user-attachments/assets/2120faa9-f05d-418a-89d4-c95e11c72355" />
<img width="1317" height="906" alt="screenshot_20251128_110531" src="https://github.com/user-attachments/assets/940079c3-8e0f-4aa6-9117-048890e81804" />
<img width="318" height="373" alt="screenshot_20251128_110558" src="https://github.com/user-attachments/assets/60eb2208-7a2f-41da-8b04-34ccb502d292" />

#### 2. **RAM Usage Module**
- Improve the tooltip to show used / max current memory
<img width="281" height="84" alt="screenshot_20251128_110458" src="https://github.com/user-attachments/assets/0f5a6e9a-009b-46aa-abcc-d832d42605bf" />
