### PR TITLE
fix: incorrect input gaming icon

### DIFF
--- a/src/components/menus/bluetooth/utils.ts
+++ b/src/components/menus/bluetooth/utils.ts
@@ -18,7 +18,7 @@ const getBluetoothIcon = (iconName: string): string => {
         ['^bluetooth*', '󰂯'],
         ['^camera*', '󰄀'],
         ['^computer*', '󰟀'],
-        ['^input-gaming*', '󰍬'],
+        ['^input-gaming*', '󰊖'],
         ['^input-keyboard*', '󰌌'],
         ['^input-mouse*', '󰍽'],
         ['^input-tablet*', '󰓶'],


### PR DESCRIPTION
The icon for input-gaming was set as a microphone, but this class is mostly for gamepads, so `nf-md-gamepad` was chosen. The reason to choose `nf-md-gamepad` and not `nf-fa-gamepad` was just to follow the convention of the other icons, that are favoring material design over font awesome.