### PR TITLE
Keyboard layout shortening

### DIFF
--- a/src/components/bar/modules/kblayout/helpers/index.ts
+++ b/src/components/bar/modules/kblayout/helpers/index.ts
@@ -1,5 +1,10 @@
 import { LayoutKeys, layoutMap, LayoutValues } from './layouts';
-import { KbLabelType, HyprctlDeviceLayout, HyprctlKeyboard } from './types';
+import {
+    KbLabelType,
+    HyprctlDeviceLayout,
+    HyprctlKeyboard,
+    KeyboardLayoutShorteningRules,
+} from './types';
 
 /**
  * Retrieves the keyboard layout from a given JSON string and format.
@@ -12,7 +17,11 @@ import { KbLabelType, HyprctlDeviceLayout, HyprctlKeyboard } from './types';
  *
  * @returns The keyboard layout in the specified format. If no keyboards are found, returns 'Unknown' or 'Unknown Layout'.
  */
-export const getKeyboardLayout = (layoutData: string, format: KbLabelType): LayoutKeys | LayoutValues => {
+export const getKeyboardLayout = (
+    layoutData: string,
+    format: KbLabelType,
+    shorteningRules?: KeyboardLayoutShorteningRules,
+): string => {
     const hyprctlDevices: HyprctlDeviceLayout = JSON.parse(layoutData);
     const keyboards = hyprctlDevices['keyboards'];
 
@@ -33,8 +42,9 @@ export const getKeyboardLayout = (layoutData: string, format: KbLabelType): Layo
     const layout: LayoutKeys = mainKb.active_keymap;
 
     const foundLayout: LayoutValues = layoutMap[layout];
+    const formattedLayout: string = format === 'code' ? (foundLayout ?? layout) : layout;
 
-    return format === 'code' ? (foundLayout ?? layout) : layout;
+    return applyShorteningRules(formattedLayout, layout, shorteningRules);
 };
 
 function isValidLayout(kbLayout: string): kbLayout is LayoutKeys {
@@ -43,4 +53,16 @@ function isValidLayout(kbLayout: string): kbLayout is LayoutKeys {
     }
 
     return true;
+}
+
+function applyShorteningRules(
+    formattedLayout: string,
+    layoutKey: string,
+    rules?: KeyboardLayoutShorteningRules,
+): string {
+    if (!rules) {
+        return formattedLayout;
+    }
+
+    return rules[formattedLayout] ?? rules[layoutKey] ?? formattedLayout;
 }

--- a/src/components/bar/modules/kblayout/helpers/types.ts
+++ b/src/components/bar/modules/kblayout/helpers/types.ts
@@ -1,4 +1,5 @@
 export type KbLabelType = 'layout' | 'code';
+export type KeyboardLayoutShorteningRules = Record<string, string>;
 
 export type HyprctlKeyboard = {
     address: string;

--- a/src/components/bar/modules/kblayout/index.tsx
+++ b/src/components/bar/modules/kblayout/index.tsx
@@ -11,13 +11,22 @@ import options from 'src/configuration';
 const inputHandler = InputHandlerService.getInstance();
 
 const hyprlandService = AstalHyprland.get_default();
-const { label, labelType, icon, leftClick, rightClick, middleClick, scrollUp, scrollDown } =
-    options.bar.customModules.kbLayout;
+const {
+    label,
+    labelType,
+    icon,
+    leftClick,
+    rightClick,
+    middleClick,
+    scrollUp,
+    scrollDown,
+    shorteningRules,
+} = options.bar.customModules.kbLayout;
 
 function setLabel(self: Astal.Label): void {
     try {
         const devices = hyprlandService.message('j/devices');
-        self.label = getKeyboardLayout(devices, labelType.get());
+        self.label = getKeyboardLayout(devices, labelType.get(), shorteningRules.get());
     } catch (error) {
         console.error(error);
     }
@@ -40,6 +49,10 @@ export const KbInput = (): BarBoxChild => {
             );
 
             useHook(self, labelType, () => {
+                setLabel(self);
+            });
+
+            useHook(self, shorteningRules, () => {
                 setLabel(self);
             });
         },

--- a/src/components/bar/settings/config.tsx
+++ b/src/components/bar/settings/config.tsx
@@ -326,6 +326,12 @@ export const CustomModuleSettings = (): JSX.Element => {
                     enums={['layout', 'code']}
                 />
                 <Option
+                    opt={options.bar.customModules.kbLayout.shorteningRules}
+                    title="Shortening Rules"
+                    subtitle="JSON map of layout -> shorthand label. Matches before HyprPanel defaults."
+                    type="object"
+                />
+                <Option
                     opt={options.theme.bar.buttons.modules.kbLayout.spacing}
                     title="Spacing"
                     type="string"

--- a/src/configuration/modules/config/bar/kbLayout/index.ts
+++ b/src/configuration/modules/config/bar/kbLayout/index.ts
@@ -1,10 +1,14 @@
-import { KbLabelType } from 'src/components/bar/modules/kblayout/helpers/types';
+import {
+    KbLabelType,
+    KeyboardLayoutShorteningRules,
+} from 'src/components/bar/modules/kblayout/helpers/types';
 import { opt } from 'src/lib/options';
 
 export default {
     label: opt(true),
     labelType: opt<KbLabelType>('code'),
     icon: opt('󰌌'),
+    shorteningRules: opt<KeyboardLayoutShorteningRules>({}),
     leftClick: opt(''),
     rightClick: opt(''),
     middleClick: opt(''),


### PR DESCRIPTION
allow defining shorter keyboard layout strings
    
e.g. in my config i use this:
    
```
      "bar.customModules.kbLayout.shorteningRules": {
        "US (Dvorak)": "DV",
        "US": "QW"
      },
   