### PR TITLE
feat(hyprsunset): Add option to send no temperature

### DIFF
--- a/src/components/bar/modules/hyprsunset/helpers/index.ts
+++ b/src/components/bar/modules/hyprsunset/helpers/index.ts
@@ -27,7 +27,9 @@ export const isActive = Variable(false);
 export const toggleSunset = (isActive: Variable<boolean>): void => {
     execAsync(isActiveCommand).then((res) => {
         if (res === 'no') {
-            execAsync(`bash -c "nohup hyprsunset -t ${temperature.get()} > /dev/null 2>&1 &"`).then(() => {
+            const curTemperature = temperature.get();
+            const parameter = curTemperature === 'none' ? '' : `-t ${curTemperature}`;
+            execAsync(`bash -c "nohup hyprsunset ${parameter} > /dev/null 2>&1 &"`).then(() => {
                 execAsync(isActiveCommand).then((res) => {
                     isActive.set(res === 'yes');
                 });

--- a/src/components/bar/settings/config.tsx
+++ b/src/components/bar/settings/config.tsx
@@ -512,7 +512,7 @@ export const CustomModuleSettings = (): JSX.Element => {
                 <Option
                     opt={options.bar.customModules.hyprsunset.temperature}
                     title="Temperature"
-                    subtitle="Ex: 1000k, 2000k, 5000k, etc."
+                    subtitle="Ex: 1000k, 2000k, 5000k, etc., or 'none' for default"
                     type="string"
                 />
                 <Option


### PR DESCRIPTION
For users with time-based temperature configurations in hyprsunset.conf, sending an explicit temperature value overrides the configuration file settings. This PR adds a 'none' option that allows hyprsunset to use its default configuration without override.