### PR TITLE
chore: replace deprecated swww command with the direct successor awww

### DIFF
--- a/src/components/settings/pages/theme/menus/matugen.tsx
+++ b/src/components/settings/pages/theme/menus/matugen.tsx
@@ -20,7 +20,7 @@ export const Matugen = (): JSX.Element => {
                     opt={options.theme.matugen}
                     title="Enable Matugen"
                     type="boolean"
-                    dependencies={['matugen', 'swww']}
+                    dependencies={['matugen', 'awww']}
                 />
                 <Option
                     opt={options.theme.matugen_settings.mode}

--- a/src/services/cli/commander/commands/system/dependencies/optional.ts
+++ b/src/services/cli/commander/commands/system/dependencies/optional.ts
@@ -37,10 +37,10 @@ export const optionalDependencies: Dependency[] = [
         description: 'Switch power profiles',
     },
     {
-        package: 'swww',
+        package: 'awww',
         required: false,
         type: 'executable',
-        check: ['swww'],
+        check: ['awww'],
         description: 'Setting wallpapers',
     },
     {

--- a/src/services/wallpaper/AwwwDaemon.ts
+++ b/src/services/wallpaper/AwwwDaemon.ts
@@ -2,9 +2,9 @@ import { execAsync } from 'astal/process';
 import { SystemUtilities } from 'src/core/system/SystemUtilities';
 
 /**
- * Manages the lifecycle of the swww daemon process
+ * Manages the lifecycle of the awww daemon process
  */
-export class SwwwDaemon {
+export class AwwwDaemon {
     private _isRunning = false;
 
     /**
@@ -15,24 +15,24 @@ export class SwwwDaemon {
     }
 
     /**
-     * Checks if swww is installed on the system
+     * Checks if awww is installed on the system
      */
     public isInstalled(): boolean {
-        return SystemUtilities.checkDependencies('swww');
+        return SystemUtilities.checkDependencies('awww');
     }
 
     /**
-     * Starts the swww daemon if not already running
+     * Starts the awww daemon if not already running
      */
     public async start(): Promise<boolean> {
         if (!this.isInstalled()) {
-            console.warn('swww is not installed, cannot start daemon');
+            console.warn('awww is not installed, cannot start daemon');
             return false;
         }
 
         const isAlreadyRunning = await this._checkIfRunning();
         if (isAlreadyRunning) {
-            console.debug('swww-daemon is already running...');
+            console.debug('awww-daemon is already running...');
             this._isRunning = true;
             return true;
         }
@@ -41,11 +41,11 @@ export class SwwwDaemon {
     }
 
     /**
-     * Stops the swww daemon
+     * Stops the awww daemon
      */
     public async stop(): Promise<void> {
         try {
-            await execAsync('swww kill');
+            await execAsync('awww kill');
             this._isRunning = false;
         } catch (err) {
             await this._handleStopError(err);
@@ -53,11 +53,11 @@ export class SwwwDaemon {
     }
 
     /**
-     * Checks if the swww daemon is currently running
+     * Checks if the awww daemon is currently running
      */
     private async _checkIfRunning(): Promise<boolean> {
         try {
-            await execAsync('swww query');
+            await execAsync('awww query');
             return true;
         } catch {
             return false;
@@ -65,11 +65,11 @@ export class SwwwDaemon {
     }
 
     /**
-     * Starts a new swww daemon instance
+     * Starts a new awww daemon instance
      */
     private async _startNewDaemon(): Promise<boolean> {
         try {
-            await execAsync('swww-daemon');
+            await execAsync('awww-daemon');
 
             const ready = await this._waitForReady();
             this._isRunning = ready;
@@ -81,7 +81,7 @@ export class SwwwDaemon {
 
             return ready;
         } catch (err) {
-            console.error('Failed to start swww-daemon:', err);
+            console.error('Failed to start awww-daemon:', err);
             this._isRunning = false;
             return false;
         }
@@ -92,9 +92,9 @@ export class SwwwDaemon {
      */
     private async _cleanupFailedDaemon(): Promise<void> {
         try {
-            await execAsync('swww kill');
+            await execAsync('awww kill');
         } catch {}
-        console.error('swww-daemon failed to become ready');
+        console.error('awww-daemon failed to become ready');
     }
 
     /**
@@ -104,16 +104,16 @@ export class SwwwDaemon {
         const wasRunning = await this._checkIfRunning();
 
         if (wasRunning) {
-            console.error('[SwwwDaemon] Failed to stop swww-daemon:', err);
+            console.error('[AwwwDaemon] Failed to stop awww-daemon:', err);
         } else {
-            console.debug('[SwwwDaemon] swww-daemon was not running');
+            console.debug('[AwwwDaemon] awww-daemon was not running');
         }
 
         this._isRunning = false;
     }
 
     /**
-     * Waits for swww daemon to be ready using exponential backoff
+     * Waits for awww daemon to be ready using exponential backoff
      */
     private async _waitForReady(): Promise<boolean> {
         const maxAttempts = 10;
@@ -121,7 +121,7 @@ export class SwwwDaemon {
 
         for (let i = 0; i < maxAttempts; i++) {
             try {
-                await execAsync('swww query');
+                await execAsync('awww query');
                 return true;
             } catch {
                 if (i < maxAttempts - 1) {

--- a/src/services/wallpaper/index.ts
+++ b/src/services/wallpaper/index.ts
@@ -3,13 +3,13 @@ import { monitorFile } from 'astal/file';
 import AstalHyprland from 'gi://AstalHyprland?version=0.1';
 import options from 'src/configuration';
 import { SystemUtilities } from 'src/core/system/SystemUtilities';
-import { SwwwDaemon } from './SwwwDaemon';
+import { AwwwDaemon } from './AwwwDaemon';
 
 const hyprlandService = AstalHyprland.get_default();
 const WP = `${GLib.get_home_dir()}/.config/background`;
 
 /**
- * Service for managing desktop wallpaper using swww daemon
+ * Service for managing desktop wallpaper using awww daemon
  */
 @register({ GTypeName: 'Wallpaper' })
 export class WallpaperService extends GObject.Object {
@@ -21,7 +21,7 @@ export class WallpaperService extends GObject.Object {
 
     private static _instance: WallpaperService;
     private _blockMonitor = false;
-    private _daemon = new SwwwDaemon();
+    private _daemon = new AwwwDaemon();
 
     constructor() {
         super();
@@ -79,25 +79,25 @@ export class WallpaperService extends GObject.Object {
     /**
      * Checks if the wallpaper service is currently running
      *
-     * @returns Whether swww daemon is active
+     * @returns Whether awww daemon is active
      */
     public isRunning(): boolean {
         return this._daemon.isRunning;
     }
 
     /**
-     * Applies the wallpaper using swww with a transition effect from cursor position
+     * Applies the wallpaper using awww with a transition effect from cursor position
      */
     private _wallpaper(): void {
         if (!this._daemon.isRunning) {
-            console.warn('Cannot set wallpaper: swww-daemon is not running');
+            console.warn('Cannot set wallpaper: awww-daemon is not running');
             return;
         }
 
         try {
             const cursorPosition = hyprlandService.message('cursorpos');
             const transitionCmd = [
-                'swww',
+                'awww',
                 'img',
                 '--invert-y',
                 '--transition-type',


### PR DESCRIPTION
This is needed since the old dependency has been deprecated some times ago and the theme extractor is not working correctly with the new package name.