### PR TITLE
fix(notifications): hide action bar when all actions have empty IDs

### DIFF
--- a/src/components/notifications/Actions/index.tsx
+++ b/src/components/notifications/Actions/index.tsx
@@ -46,7 +46,7 @@ export const Actions = ({ notification, showActions }: ActionProps): JSX.Element
         >
             <eventbox>
                 <box className={'notification-card-actions'} hexpand valign={Gtk.Align.END}>
-                    {notification.get_actions().map((action) => {
+                    {notification.get_actions().filter((a) => a.id !== '').map((action) => {
                         return <ActionButton notification={notification} action={action} />;
                     })}
                 </box>

--- a/src/components/notifications/Notification/index.tsx
+++ b/src/components/notifications/Notification/index.tsx
@@ -29,7 +29,7 @@ export const NotificationCard = ({
 }: NotificationCardProps): JSX.Element => {
     let actionBox: ActionBox | null;
 
-    if (notification.get_actions().length) {
+    if (notification.get_actions().filter((a) => a.id !== '').length) {
         actionBox = <Actions notification={notification} showActions={showActions} />;
     } else {
         actionBox = null;


### PR DESCRIPTION
## Problem

Some applications (e.g. Claude Code) send notifications with an empty action — an action where `id` is an empty string `""`. The `NotificationCard` guard checks `get_actions().length`, which is `> 0` for this empty action, so the `Actions` component gets rendered. But since there are no real buttons, the result is a blank pale bar visible at the bottom of the notification popup.

![Empty action bar](https://github.com/user-attachments/assets/placeholder)

## Fix

Filter out actions with an empty `id` before:
1. The guard in `Notification/index.tsx` — so `actionBox` stays `null` and the bar is never rendered
2. The `map` in `Actions/index.tsx` — defensive filter so the button list is also clean if `Actions` is ever called directly

```diff
- if (notification.get_actions().length) {
+ if (notification.get_actions().filter((a) => a.id !== '').length) {
```

```diff
- {notification.get_actions().map((action) => {
+ {notification.get_actions().filter((a) => a.id !== '').map((action) => {
```

## Testing

- Notifications with no real actions (empty `id`): action bar is hidden
- Notifications with real actions: action buttons render as before