### PR TITLE
feat(workspaces): support workspace name keys in workspaceIconMap

### DIFF
--- a/src/components/bar/modules/workspaces/helpers/index.ts
+++ b/src/components/bar/modules/workspaces/helpers/index.ts
@@ -38,8 +38,8 @@ const isWorkspaceActiveOnMonitor = (monitor: number, i: number): boolean => {
  *
  * @returns The icon for the workspace as a string. If no icon is found, returns the workspace index as a string.
  */
-const getWsIcon = (wsIconMap: WorkspaceIconMap, i: number): string => {
-    const iconEntry = wsIconMap[i];
+const getWsIcon = (wsIconMap: WorkspaceIconMap, i: number, wsName?: string): string => {
+    const iconEntry = (wsName !== undefined ? wsIconMap[wsName] : undefined) ?? wsIconMap[i];
     const defaultIcon = `${i}`;
 
     if (iconEntry === undefined) {
@@ -77,8 +77,9 @@ export const getWsColor = (
     i: number,
     smartHighlight: boolean,
     monitor: number,
+    wsName?: string,
 ): string => {
-    const iconEntry = wsIconMap[i];
+    const iconEntry = (wsName !== undefined ? wsIconMap[wsName] : undefined) ?? wsIconMap[i];
     const hasColor =
         typeof iconEntry === 'object' && 'color' in iconEntry && isValidGjsColor(iconEntry.color);
 
@@ -253,6 +254,7 @@ export const renderLabel = (
     i: number,
     index: number,
     monitor: number,
+    wsName?: string,
 ): string => {
     if (showAppIcons) {
         return appIcons;
@@ -271,7 +273,7 @@ export const renderLabel = (
     }
 
     if (showWorkspaceIcons) {
-        return getWsIcon(wsIconMap, i);
+        return getWsIcon(wsIconMap, i, wsName);
     }
 
     return workspaceMask ? `${index + 1}` : `${i}`;

--- a/src/components/bar/modules/workspaces/workspaces.tsx
+++ b/src/components/bar/modules/workspaces/workspaces.tsx
@@ -102,6 +102,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
             );
 
             return workspacesToRender.map((wsId, index) => {
+                const wsName = workspaceList.find((ws) => ws.id === wsId)?.name;
                 const appIcons = displayApplicationIcons
                     ? getAppIcon(wsId, appIconOncePerWorkspace, {
                           iconMap: applicationIconMapping,
@@ -123,7 +124,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                             valign={Gtk.Align.CENTER}
                             css={
                                 `margin: 0rem ${0.375 * spacingValue}rem;` +
-                                `${displayWorkspaceIcons && !matugenEnabled ? getWsColor(workspaceIconMapping, wsId, smartHighlightEnabled, monitor) : ''}`
+                                `${displayWorkspaceIcons && !matugenEnabled ? getWsColor(workspaceIconMapping, wsId, smartHighlightEnabled, monitor, wsName) : ''}`
                             }
                             className={renderClassnames(
                                 displayIcons,
@@ -147,6 +148,7 @@ export const WorkspaceModule = ({ monitor }: WorkspaceModuleProps): JSX.Element 
                                 wsId,
                                 index,
                                 monitor,
+                                wsName,
                             )}
                             setup={(self) => {
                                 const currentWsClients = clients.filter(


### PR DESCRIPTION
Special workspaces in Hyprland receive non-deterministic negative IDs based on creation order at runtime, making numeric key mappings unreliable across reboots. This adds support for named keys (e.g. "special:discord") in workspaceIconMap, with name-based lookup taking priority over numeric ID lookup as a fallback.

Closes #1190